### PR TITLE
Implement backend file upload & storage (local adapter)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5030,9 +5030,11 @@ name = "zaps-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64 0.21.7",
  "bcrypt",
+ "bytes",
  "chrono",
  "config",
  "dashmap",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -60,6 +60,8 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1.10"
 base64 = "0.21"
+async-trait = "0.1"
+bytes = "1.5"
 
 # Metrics & monitoring
 prometheus = "0.13"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub compliance_config: ComplianceConfig,
     pub environment: EnvironmentType,
     pub rate_limit: RateLimitConfig,
+    pub storage: StorageConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -90,6 +91,23 @@ pub struct RiskThresholds {
     pub high_risk_amount: u64,
     pub medium_risk_amount: u64,
     pub suspicious_patterns: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum StorageBackend {
+    Local,
+    S3,
+    Ipfs,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    pub backend: StorageBackend,
+    pub local_path: Option<String>,
+    pub s3_bucket: Option<String>,
+    pub s3_region: Option<String>,
+    pub ipfs_gateway: Option<String>,
 }
 
 impl Config {
@@ -165,6 +183,13 @@ impl Default for Config {
                 window_ms: 60000, // 1 minute
                 max_requests: 100,
                 scope: RateLimitScope::Ip,
+            },
+            storage: StorageConfig {
+                backend: StorageBackend::Local,
+                local_path: Some("./uploads".to_string()),
+                s3_bucket: None,
+                s3_region: None,
+                ipfs_gateway: None,
             },
         }
     }

--- a/backend/src/http/files.rs
+++ b/backend/src/http/files.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Bytes,
+    extract::{Multipart, Path, State},
+    http::StatusCode,
+    Json,
+};
+
+use crate::{
+    api_error::ApiError,
+    models::FileUploadResponseDto,
+    service::ServiceContainer,
+};
+
+const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10MB
+const ALLOWED_MIME_TYPES: &[&str] = &["image/png", "image/jpeg", "application/pdf"];
+
+pub async fn upload_file(
+    State(services): State<Arc<ServiceContainer>>,
+    mut multipart: Multipart,
+) -> Result<Json<FileUploadResponseDto>, ApiError> {
+    let mut file_name = None;
+    let mut content_type = None;
+    let mut data = Bytes::new();
+
+    while let Some(field) = multipart.next_field().await.map_err(|e| {
+        ApiError::Validation(format!("Failed to parse multipart form: {}", e))
+    })? {
+        if field.name() == Some("file") {
+            file_name = field.file_name().map(|s| s.to_string());
+            content_type = field.content_type().map(|s| s.to_string());
+
+            let bytes = field
+                .bytes()
+                .await
+                .map_err(|e| ApiError::Validation(format!("Failed to read file bytes: {}", e)))?;
+
+            if bytes.len() as u64 > MAX_FILE_SIZE {
+                return Err(ApiError::Validation("File size exceeds 10MB limit".to_string()));
+            }
+
+            data = bytes;
+            break;
+        }
+    }
+
+    let file_name = file_name.ok_or_else(|| ApiError::Validation("file field is required".to_string()))?;
+    let mime_type = content_type.ok_or_else(|| ApiError::Validation("Missing content type".to_string()))?;
+
+    if !ALLOWED_MIME_TYPES.contains(&mime_type.as_str()) {
+        return Err(ApiError::Validation("Unsupported file type".to_string()));
+    }
+
+    // Placeholder virus scan hook - always passes. Replace with real AV integration.
+    // In a real implementation, you would stream `data` to an antivirus engine here.
+
+    let stored = services
+        .storage
+        .adapter
+        .upload(data, &file_name, &mime_type)
+        .await
+        .map_err(|_| ApiError::InternalServerError)?;
+
+    Ok(Json(FileUploadResponseDto {
+        file_id: stored.id,
+        original_name: stored.original_name,
+        mime_type: stored.mime_type,
+        size: stored.size,
+        url: stored.url,
+    }))
+}
+
+pub async fn get_file(
+    State(services): State<Arc<ServiceContainer>>,
+    Path(id): Path<String>,
+) -> Result<Json<FileUploadResponseDto>, ApiError> {
+    let stored = services
+        .storage
+        .adapter
+        .get(&id)
+        .await
+        .map_err(|_| ApiError::InternalServerError)?;
+
+    let stored = stored.ok_or_else(|| ApiError::NotFound("File not found".to_string()))?;
+
+    Ok(Json(FileUploadResponseDto {
+        file_id: stored.id,
+        original_name: stored.original_name,
+        mime_type: stored.mime_type,
+        size: stored.size,
+        url: stored.url,
+    }))
+}
+
+pub async fn delete_file(
+    State(services): State<Arc<ServiceContainer>>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    services
+        .storage
+        .adapter
+        .delete(&id)
+        .await
+        .map_err(|_| ApiError::InternalServerError)?;
+
+    // DELETE is idempotent: always return 204 even if file didn't exist
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/backend/src/http/mod.rs
+++ b/backend/src/http/mod.rs
@@ -6,6 +6,7 @@ pub mod notifications;
 pub mod payments;
 pub mod transfers;
 pub mod withdrawals;
+pub mod files;
 
 pub use admin::*;
 pub use auth::*;
@@ -15,3 +16,4 @@ pub use notifications::*;
 pub use payments::*;
 pub use transfers::*;
 pub use withdrawals::*;
+pub use files::*;

--- a/backend/src/http/notifications.rs
+++ b/backend/src/http/notifications.rs
@@ -36,7 +36,8 @@ pub struct NotificationResponseDto {
 
 #[derive(Debug, Deserialize)]
 pub struct NotificationQuery {
-    pub userId: String,
+    #[serde(rename = "userId")]
+    pub user_id: String,
 }
 
 pub async fn create_notification(
@@ -74,7 +75,7 @@ pub async fn get_notifications(
 ) -> Result<Json<Vec<NotificationResponseDto>>, ApiError> {
     let notifications = services
         .notification
-        .get_user_notifications(&query.userId)
+        .get_user_notifications(&query.user_id)
         .await?;
 
     let response = notifications

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,6 +10,7 @@ pub mod role;
 // pub mod realtime; // TODO: Implement when needed
 pub mod service;
 pub mod telemetry;
+pub mod storage;
 
 pub use api_error::ApiError;
 pub use app::create_app;

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -282,3 +282,13 @@ pub struct RateLimitConfig {
     pub max_requests: u32,
     pub scope: RateLimitScope,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileUploadResponseDto {
+    pub file_id: String,
+    pub original_name: String,
+    pub mime_type: String,
+    pub size: i64,
+    pub url: String,
+}

--- a/backend/src/service/mod.rs
+++ b/backend/src/service/mod.rs
@@ -7,6 +7,7 @@ pub mod indexer_service;
 pub mod payment_service;
 pub mod notification_service;
 pub mod rate_limit_service;
+pub mod storage_service;
 
 pub use anchor_service::AnchorService;
 pub use audit_service::AuditService;
@@ -17,6 +18,7 @@ pub use indexer_service::IndexerService;
 pub use payment_service::PaymentService;
 pub use notification_service::NotificationService;
 pub use rate_limit_service::RateLimitService;
+pub use storage_service::StorageService;
 
 use crate::config::Config;
 use deadpool_postgres::Pool;
@@ -33,6 +35,7 @@ pub struct ServiceContainer {
     pub indexer: IndexerService,
     pub notification: NotificationService,
     pub rate_limit: RateLimitService,
+    pub storage: StorageService,
     pub config: Config,
     pub db_pool: Arc<Pool>,
 }
@@ -50,6 +53,7 @@ impl ServiceContainer {
         let indexer = IndexerService::new(db_pool.clone(), config.clone());
         let notification = NotificationService::new(db_pool.clone(), config.clone());
         let rate_limit = RateLimitService::new(config.clone());
+        let storage = StorageService::new(config.clone());
 
         Ok(Self {
             identity,
@@ -61,6 +65,7 @@ impl ServiceContainer {
             indexer,
             notification,
             rate_limit,
+            storage,
             config,
             db_pool,
         })

--- a/backend/src/service/notification_service.rs
+++ b/backend/src/service/notification_service.rs
@@ -11,7 +11,6 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub struct NotificationService {
     db_pool: Arc<Pool>,
-    config: Config,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -24,8 +23,8 @@ pub struct CreateNotificationRequest {
 }
 
 impl NotificationService {
-    pub fn new(db_pool: Arc<Pool>, config: Config) -> Self {
-        Self { db_pool, config }
+    pub fn new(db_pool: Arc<Pool>, _config: Config) -> Self {
+        Self { db_pool }
     }
 
     pub async fn create_notification(

--- a/backend/src/service/storage_service.rs
+++ b/backend/src/service/storage_service.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use crate::config::{Config, StorageBackend};
+use crate::storage::{IPFSStorageAdapter, LocalStorageAdapter, S3StorageAdapter, StorageAdapter};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct StorageService {
+    pub adapter: Arc<dyn StorageAdapter>,
+}
+
+impl StorageService {
+    pub fn new(config: Config) -> Self {
+        let adapter: Arc<dyn StorageAdapter> = match config.storage.backend {
+            StorageBackend::Local => {
+                let base_path = config
+                    .storage
+                    .local_path
+                    .clone()
+                    .unwrap_or_else(|| "./uploads".to_string());
+                let public_base_url = "/files".to_string();
+                Arc::new(LocalStorageAdapter::new(PathBuf::from(base_path), public_base_url))
+            }
+            StorageBackend::S3 => Arc::new(S3StorageAdapter::new()),
+            StorageBackend::Ipfs => Arc::new(IPFSStorageAdapter::new()),
+        };
+
+        Self { adapter }
+    }
+}

--- a/backend/src/storage/ipfs.rs
+++ b/backend/src/storage/ipfs.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use super::{StorageAdapter, StoredFile};
+
+#[derive(Clone)]
+pub struct IPFSStorageAdapter;
+
+impl IPFSStorageAdapter {
+    pub fn new() -> Self {
+        // TODO: wire real IPFS client and gateway config
+        Self
+    }
+}
+
+#[async_trait]
+impl StorageAdapter for IPFSStorageAdapter {
+    async fn upload(&self, _data: Bytes, _file_name: &str, _mime_type: &str) -> anyhow::Result<StoredFile> {
+        // Placeholder implementation
+        Err(anyhow::anyhow!("IPFSStorageAdapter is not implemented"))
+    }
+
+    async fn get(&self, _id: &str) -> anyhow::Result<Option<StoredFile>> {
+        // Placeholder implementation
+        Ok(None)
+    }
+
+    async fn delete(&self, _id: &str) -> anyhow::Result<()> {
+        // Placeholder implementation
+        Ok(())
+    }
+}

--- a/backend/src/storage/local.rs
+++ b/backend/src/storage/local.rs
@@ -1,0 +1,71 @@
+use std::{fs, path::PathBuf};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use uuid::Uuid;
+
+use super::{StorageAdapter, StoredFile};
+
+#[derive(Clone)]
+pub struct LocalStorageAdapter {
+    base_path: PathBuf,
+    public_base_url: String,
+}
+
+impl LocalStorageAdapter {
+    pub fn new(base_path: PathBuf, public_base_url: String) -> Self {
+        fs::create_dir_all(&base_path).ok();
+        Self {
+            base_path,
+            public_base_url,
+        }
+    }
+}
+
+#[async_trait]
+impl StorageAdapter for LocalStorageAdapter {
+    async fn upload(&self, data: Bytes, file_name: &str, mime_type: &str) -> anyhow::Result<StoredFile> {
+        let id = Uuid::new_v4().to_string();
+        let mut path = self.base_path.clone();
+        path.push(&id);
+
+        fs::write(&path, &data)?;
+
+        Ok(StoredFile {
+            id: id.clone(),
+            original_name: file_name.to_string(),
+            mime_type: mime_type.to_string(),
+            size: data.len() as i64,
+            url: format!("{}/{}", self.public_base_url.trim_end_matches('/'), id),
+        })
+    }
+
+    async fn get(&self, id: &str) -> anyhow::Result<Option<StoredFile>> {
+        let mut path = self.base_path.clone();
+        path.push(id);
+
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let metadata = fs::metadata(&path)?;
+        Ok(Some(StoredFile {
+            id: id.to_string(),
+            original_name: id.to_string(),
+            mime_type: "application/octet-stream".to_string(),
+            size: metadata.len() as i64,
+            url: format!("{}/{}", self.public_base_url.trim_end_matches('/'), id),
+        }))
+    }
+
+    async fn delete(&self, id: &str) -> anyhow::Result<()> {
+        let mut path = self.base_path.clone();
+        path.push(id);
+
+        if path.exists() {
+            let _ = fs::remove_file(path);
+        }
+
+        Ok(())
+    }
+}

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+
+#[derive(Debug, Clone)]
+pub struct StoredFile {
+    pub id: String,
+    pub original_name: String,
+    pub mime_type: String,
+    pub size: i64,
+    pub url: String,
+}
+
+#[async_trait]
+pub trait StorageAdapter: Send + Sync {
+    async fn upload(&self, data: Bytes, file_name: &str, mime_type: &str) -> anyhow::Result<StoredFile>;
+    async fn get(&self, id: &str) -> anyhow::Result<Option<StoredFile>>;
+    async fn delete(&self, id: &str) -> anyhow::Result<()>;
+}
+
+pub mod local;
+pub mod s3;
+pub mod ipfs;
+
+pub use local::LocalStorageAdapter;
+pub use s3::S3StorageAdapter;
+pub use ipfs::IPFSStorageAdapter;

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use super::{StorageAdapter, StoredFile};
+
+#[derive(Clone)]
+pub struct S3StorageAdapter;
+
+impl S3StorageAdapter {
+    pub fn new() -> Self {
+        // TODO: wire real S3 client and bucket config
+        Self
+    }
+}
+
+#[async_trait]
+impl StorageAdapter for S3StorageAdapter {
+    async fn upload(&self, _data: Bytes, _file_name: &str, _mime_type: &str) -> anyhow::Result<StoredFile> {
+        // Placeholder implementation
+        Err(anyhow::anyhow!("S3StorageAdapter is not implemented"))
+    }
+
+    async fn get(&self, _id: &str) -> anyhow::Result<Option<StoredFile>> {
+        // Placeholder implementation
+        Ok(None)
+    }
+
+    async fn delete(&self, _id: &str) -> anyhow::Result<()> {
+        // Placeholder implementation
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Add FileUploadResponseDto and storage abstraction (StorageAdapter),

- Implement local storage adapter and stub S3/IPFS adapters,

- Add protected /files endpoints for upload, metadata retrieval, and delete with MIME/type and 10MB size validation and a virus-scan hook placeholder,

- Wire storage service into ServiceContainer and clean up related warnings in notifications and routing,

Closes #13 