### PR TITLE
feat(security): Implement Sliding Window Rate Limiting and Admin Bypass (#148)

### DIFF
--- a/backend/config/default.toml
+++ b/backend/config/default.toml
@@ -52,6 +52,7 @@ suspicious_patterns = []
 window_ms = 60000 # 1 minute
 max_requests = 100
 scope = "IP"
+bypass_admin = true
 
 [[rate_limit.endpoint_limits]]
 path_prefix = "/auth"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -275,6 +275,7 @@ impl Default for Config {
                 max_requests: 100,
                 scope: RateLimitScope::Ip,
                 endpoint_limits: vec![],
+                bypass_admin: true,
             },
             observability: ObservabilityConfig::default(),
             cache: CacheConfig::default(),

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -1,6 +1,7 @@
 use crate::api_error::ApiError;
 use crate::middleware::auth::AuthenticatedUser;
 use crate::models::RateLimitScope;
+use crate::role::Role;
 use crate::service::{rate_limit_service::scope_name, MetricsService, ServiceContainer};
 use axum::{
     extract::{ConnectInfo, Request, State},
@@ -21,13 +22,43 @@ pub async fn rate_limit(
     let config = &services.config.rate_limit;
     let path = request.uri().path().to_string();
 
+    // Check if the user is an admin and bypass is enabled
+    let mut is_admin = false;
+    if config.bypass_admin {
+        if let Some(user) = request.extensions().get::<AuthenticatedUser>() {
+            is_admin = user.role == Role::Admin;
+        } else if let Some(auth_header) = request.headers().get("authorization") {
+            if let Ok(auth_str) = auth_header.to_str() {
+                if let Some(token) = auth_str.strip_prefix("Bearer ") {
+                    if let Ok(claims) = crate::auth::validate_access_token(token, &services.config.jwt.secret) {
+                        is_admin = claims.role == Role::Admin;
+                    }
+                }
+            }
+        }
+    }
+
+    if is_admin {
+        tracing::debug!("Admin user bypassing rate limiting");
+        return Ok(next.run(request).await);
+    }
+
     let key = match config.scope {
         RateLimitScope::Ip => addr.ip().to_string(),
-        RateLimitScope::User => request
-            .extensions()
-            .get::<AuthenticatedUser>()
-            .map(|user| user.user_id.clone())
-            .unwrap_or_else(|| addr.ip().to_string()),
+        RateLimitScope::User => {
+            if let Some(user) = request.extensions().get::<AuthenticatedUser>() {
+                user.user_id.clone()
+            } else if let Some(auth_header) = request.headers().get("authorization")
+                .and_then(|h| h.to_str().ok())
+                .and_then(|s| s.strip_prefix("Bearer "))
+            {
+                crate::auth::validate_access_token(auth_header, &services.config.jwt.secret)
+                    .map(|claims| claims.sub)
+                    .unwrap_or_else(|_| addr.ip().to_string())
+            } else {
+                addr.ip().to_string()
+            }
+        }
         RateLimitScope::ApiKey => request
             .headers()
             .get("X-API-KEY")
@@ -41,7 +72,7 @@ pub async fn rate_limit(
         .check_rate_limit(&key, &path, &config.scope)
         .await;
 
-    MetricsService::record_rate_limit_event(scope_name(&config.scope), decision.allowed);
+    MetricsService::record_rate_limit_event(scope_name(&config.scope), decision.allowed, &path);
 
     if !decision.allowed {
         tracing::warn!(

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -354,6 +354,12 @@ pub struct RateLimitConfig {
     pub scope: RateLimitScope,
     #[serde(default)]
     pub endpoint_limits: Vec<EndpointRateLimitConfig>,
+    #[serde(default = "default_bypass_admin")]
+    pub bypass_admin: bool,
+}
+
+fn default_bypass_admin() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/service/metrics_service.rs
+++ b/backend/src/service/metrics_service.rs
@@ -56,8 +56,8 @@ lazy_static! {
 
     pub static ref RATE_LIMIT_EVENTS_TOTAL: CounterVec = register_counter_vec!(
         "rate_limit_events_total",
-        "Total rate limit decisions by scope and outcome",
-        &["scope", "outcome"]
+        "Total rate limit decisions by scope, outcome, and path",
+        &["scope", "outcome", "path"]
     )
     .expect("Can't create rate_limit_events_total metric");
 
@@ -346,10 +346,11 @@ impl MetricsService {
             .inc();
     }
 
-    pub fn record_rate_limit_event(scope: &str, allowed: bool) {
+    pub fn record_rate_limit_event(scope: &str, allowed: bool, path: &str) {
         let outcome = if allowed { "allowed" } else { "blocked" };
+        let normalized_path = Self::normalize_path(path);
         RATE_LIMIT_EVENTS_TOTAL
-            .with_label_values(&[scope, outcome])
+            .with_label_values(&[scope, outcome, &normalized_path])
             .inc();
     }
 

--- a/backend/src/service/rate_limit_service.rs
+++ b/backend/src/service/rate_limit_service.rs
@@ -5,6 +5,38 @@ use redis::{aio::ConnectionManager, AsyncCommands};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
+use uuid::Uuid;
+
+const REDIS_SLIDING_WINDOW_LUA: &str = r#"
+    local key = KEYS[1]
+    local now = tonumber(ARGV[1])
+    local window = tonumber(ARGV[2])
+    local limit = tonumber(ARGV[3])
+    local member = ARGV[4]
+    
+    -- Prune expired entries
+    redis.call('zremrangebyscore', key, 0, now - window)
+    
+    -- Count remaining entries
+    local count = redis.call('zcard', key)
+    
+    local allowed = 0
+    if count < limit then
+        redis.call('zadd', key, now, member)
+        redis.call('pexpire', key, window)
+        allowed = 1
+        count = count + 1
+    end
+    
+    -- Get oldest timestamp to calculate reset
+    local oldest = redis.call('zrange', key, 0, 0, 'withscores')
+    local oldest_ts = now
+    if #oldest > 0 then
+        oldest_ts = tonumber(oldest[2])
+    end
+    
+    return {allowed, count, oldest_ts}
+"#;
 
 #[derive(Debug, Clone)]
 pub struct RateLimitDecision {
@@ -15,16 +47,15 @@ pub struct RateLimitDecision {
 }
 
 #[derive(Debug, Clone)]
-struct WindowCounter {
-    count: u32,
-    reset_at_ms: u64,
+struct LocalSlidingWindow {
+    timestamps: Vec<u64>,
 }
 
 #[derive(Clone)]
 pub struct RateLimitService {
     config: RateLimitConfig,
     redis: Arc<Mutex<Option<ConnectionManager>>>,
-    local_windows: Arc<DashMap<String, WindowCounter>>,
+    local_windows: Arc<DashMap<String, LocalSlidingWindow>>,
 }
 
 impl RateLimitService {
@@ -104,28 +135,38 @@ impl RateLimitService {
         let mut guard = self.redis.lock().await;
         let connection = guard.as_mut()?;
 
-        let count: redis::RedisResult<u32> = connection.incr(key, 1_u32).await;
-        let count = match count {
-            Ok(count) => count,
+        let now = now_ms();
+        let member = Uuid::new_v4().to_string();
+
+        let script = redis::Script::new(REDIS_SLIDING_WINDOW_LUA);
+        let result: redis::RedisResult<(u8, u32, u64)> = script
+            .key(key)
+            .arg(now)
+            .arg(window_ms)
+            .arg(max_requests)
+            .arg(&member)
+            .invoke_async(connection)
+            .await;
+
+        let (allowed, count, oldest_ts) = match result {
+            Ok(values) => values,
             Err(error) => {
-                tracing::warn!(%error, "Redis rate limit increment failed; falling back locally");
+                tracing::warn!(%error, "Redis sliding window rate limit script failed; falling back locally");
                 *guard = None;
                 return None;
             }
         };
 
-        if count == 1 {
-            let expire_result: redis::RedisResult<()> =
-                connection.pexpire(key, window_ms as i64).await;
-            if let Err(error) = expire_result {
-                tracing::warn!(%error, "Redis rate limit expiry failed");
-            }
-        }
+        let reset_after_seconds = if count > 0 {
+            let oldest_plus_window = oldest_ts.saturating_add(window_ms);
+            let time_remaining_ms = oldest_plus_window.saturating_sub(now);
+            (time_remaining_ms + 999) / 1000
+        } else {
+            (window_ms + 999) / 1000
+        };
 
-        let ttl_ms: i64 = connection.pttl(key).await.unwrap_or(window_ms as i64);
-        let reset_after_seconds = ((ttl_ms.max(0) as u64) + 999) / 1000;
         Some(RateLimitDecision {
-            allowed: count <= max_requests,
+            allowed: allowed == 1,
             limit: max_requests,
             remaining: max_requests.saturating_sub(count),
             reset_after_seconds,
@@ -134,27 +175,37 @@ impl RateLimitService {
 
     fn check_local(&self, key: &str, max_requests: u32, window_ms: u64) -> RateLimitDecision {
         let now = now_ms();
-        let reset_at_ms = now.saturating_add(window_ms);
         let mut entry = self
             .local_windows
             .entry(key.to_string())
-            .or_insert(WindowCounter {
-                count: 0,
-                reset_at_ms,
+            .or_insert(LocalSlidingWindow {
+                timestamps: Vec::new(),
             });
 
-        if now >= entry.reset_at_ms {
-            entry.count = 0;
-            entry.reset_at_ms = reset_at_ms;
+        // Retain timestamps within the window
+        let window_start = now.saturating_sub(window_ms);
+        entry.timestamps.retain(|&ts| ts > window_start);
+
+        let allowed = entry.timestamps.len() < max_requests as usize;
+        if allowed {
+            entry.timestamps.push(now);
         }
 
-        entry.count = entry.count.saturating_add(1);
-        let reset_after_seconds = (entry.reset_at_ms.saturating_sub(now) + 999) / 1000;
+        let count = entry.timestamps.len() as u32;
+        let oldest_ts = entry.timestamps.first().cloned().unwrap_or(now);
+
+        let reset_after_seconds = if count > 0 {
+            let oldest_plus_window = oldest_ts.saturating_add(window_ms);
+            let time_remaining_ms = oldest_plus_window.saturating_sub(now);
+            (time_remaining_ms + 999) / 1000
+        } else {
+            (window_ms + 999) / 1000
+        };
 
         RateLimitDecision {
-            allowed: entry.count <= max_requests,
+            allowed,
             limit: max_requests,
-            remaining: max_requests.saturating_sub(entry.count),
+            remaining: max_requests.saturating_sub(count),
             reset_after_seconds,
         }
     }

--- a/backend/tests/rate_limit_test.rs
+++ b/backend/tests/rate_limit_test.rs
@@ -1,76 +1,136 @@
-// use std::thread;
-// use std::time::Duration;
-// use blinks_backend::config::Config;
-// use blinks_backend::models::{RateLimitConfig, RateLimitScope};
-// use blinks_backend::service::RateLimitService;
+use std::time::Duration;
+use blinks_backend::config::Config;
+use blinks_backend::models::{RateLimitConfig, RateLimitScope};
+use blinks_backend::service::RateLimitService;
 
-// #[test]
-// fn test_rate_limit_enforcement() {
-//     // Setup config with strict limits: 2 requests per 1 second
-//     let config = Config::default();
-//     // config.rate_limit = RateLimitConfig {
-//     //     window_ms: 1000,
-//     //     max_requests: 2,
-//     //     scope: RateLimitScope::Ip,
-//     // };
+#[tokio::test]
+async fn test_rate_limit_enforcement() {
+    let mut config = Config::default();
+    config.rate_limit = RateLimitConfig {
+        window_ms: 1000,
+        max_requests: 2,
+        scope: RateLimitScope::Ip,
+        endpoint_limits: vec![],
+        bypass_admin: true,
+    };
 
-//     let rate_limit_service = RateLimitService::new(config);
-//     let key = "127.0.0.1".to_string();
+    let rate_limit_service = RateLimitService::new(config).await;
+    let key = "127.0.0.1";
+    let path = "/test";
+    let scope = RateLimitScope::Ip;
 
-//     // First request should pass
-//     assert!(rate_limit_service.check_rate_limit(key.clone()));
+    // First request should pass
+    let decision1 = rate_limit_service.check_rate_limit(key, path, &scope).await;
+    assert!(decision1.allowed);
+    assert_eq!(decision1.limit, 2);
+    assert_eq!(decision1.remaining, 1);
 
-//     // Second request should pass
-//     assert!(rate_limit_service.check_rate_limit(key.clone()));
+    // Second request should pass
+    let decision2 = rate_limit_service.check_rate_limit(key, path, &scope).await;
+    assert!(decision2.allowed);
+    assert_eq!(decision2.remaining, 0);
 
-//     // Third request should fail
-//     assert!(!rate_limit_service.check_rate_limit(key.clone()));
-// }
+    // Third request should fail
+    let decision3 = rate_limit_service.check_rate_limit(key, path, &scope).await;
+    assert!(!decision3.allowed);
+}
 
-// #[test]
-// fn test_rate_limit_expiry() {
-//     // Setup config: 1 request per 100ms
-//     let config = Config::default();
-//     // config.rate_limit = RateLimitConfig {
-//     //     window_ms: 100,
-//     //     max_requests: 1,
-//     //     scope: RateLimitScope::Ip,
-//     // };
+#[tokio::test]
+async fn test_rate_limit_expiry() {
+    let mut config = Config::default();
+    config.rate_limit = RateLimitConfig {
+        window_ms: 200,
+        max_requests: 1,
+        scope: RateLimitScope::Ip,
+        endpoint_limits: vec![],
+        bypass_admin: true,
+    };
 
-//     let rate_limit_service = RateLimitService::new(config);
-//     let key = "127.0.0.1".to_string();
+    let rate_limit_service = RateLimitService::new(config).await;
+    let key = "127.0.0.1";
+    let path = "/test";
+    let scope = RateLimitScope::Ip;
 
-//     // First request passes
-//     assert!(rate_limit_service.check_rate_limit(key.clone()));
+    // First request passes
+    let decision1 = rate_limit_service.check_rate_limit(key, path, &scope).await;
+    assert!(decision1.allowed);
 
-//     // Immediate second request fails
-//     assert!(!rate_limit_service.check_rate_limit(key.clone()));
+    // Immediate second request fails
+    let decision2 = rate_limit_service.check_rate_limit(key, path, &scope).await;
+    assert!(!decision2.allowed);
 
-//     // Wait for window to expire
-//     thread::sleep(Duration::from_millis(150));
+    // Wait for window to expire
+    tokio::time::sleep(Duration::from_millis(250)).await;
 
-//     // Request should pass again
-//     assert!(rate_limit_service.check_rate_limit(key.clone()));
-// }
+    // Request should pass again
+    let decision3 = rate_limit_service.check_rate_limit(key, path, &scope).await;
+    assert!(decision3.allowed);
+}
 
-// #[test]
-// fn test_independent_limits() {
-//     // Setup config: 1 request per second
-//     let config = Config::default();
-//     // config.rate_limit = RateLimitConfig {
-//     //     window_ms: 1000,
-//     //     max_requests: 1,
-//     //     scope: RateLimitScope::Ip,
-//     // };
+#[tokio::test]
+async fn test_independent_limits() {
+    let mut config = Config::default();
+    config.rate_limit = RateLimitConfig {
+        window_ms: 1000,
+        max_requests: 1,
+        scope: RateLimitScope::Ip,
+        endpoint_limits: vec![],
+        bypass_admin: true,
+    };
 
-//     let rate_limit_service = RateLimitService::new(config);
-//     let key1 = "127.0.0.1".to_string();
-//     let key2 = "192.168.1.1".to_string();
+    let rate_limit_service = RateLimitService::new(config).await;
+    let key1 = "127.0.0.1";
+    let key2 = "192.168.1.1";
+    let path = "/test";
+    let scope = RateLimitScope::Ip;
 
-//     // Key1 uses its quota
-//     assert!(rate_limit_service.check_rate_limit(key1.clone()));
-//     assert!(!rate_limit_service.check_rate_limit(key1.clone()));
+    // Key1 uses its quota
+    let decision1 = rate_limit_service.check_rate_limit(key1, path, &scope).await;
+    assert!(decision1.allowed);
+    
+    let decision2 = rate_limit_service.check_rate_limit(key1, path, &scope).await;
+    assert!(!decision2.allowed);
 
-//     // Key2 should still be allowed
-//     assert!(rate_limit_service.check_rate_limit(key2.clone()));
-// }
+    // Key2 should still be allowed
+    let decision3 = rate_limit_service.check_rate_limit(key2, path, &scope).await;
+    assert!(decision3.allowed);
+}
+
+#[tokio::test]
+async fn test_sliding_window_burst() {
+    let mut config = Config::default();
+    config.rate_limit = RateLimitConfig {
+        window_ms: 300,
+        max_requests: 2,
+        scope: RateLimitScope::Ip,
+        endpoint_limits: vec![],
+        bypass_admin: true,
+    };
+
+    let rate_limit_service = RateLimitService::new(config).await;
+    let key = "127.0.0.1";
+    let path = "/test";
+    let scope = RateLimitScope::Ip;
+
+    // Request 1 at t=0ms (allowed)
+    assert!(rate_limit_service.check_rate_limit(key, path, &scope).await.allowed);
+
+    // Sleep 100ms
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Request 2 at t=100ms (allowed)
+    assert!(rate_limit_service.check_rate_limit(key, path, &scope).await.allowed);
+
+    // Request 3 at t=120ms (blocked - limit of 2 reached)
+    assert!(!rate_limit_service.check_rate_limit(key, path, &scope).await.allowed);
+
+    // Sleep 250ms (total time ~350ms).
+    // Request 1 (at t=0ms) has fallen out of the 300ms window, but Request 2 (at t=100ms) is still inside (100ms + 300ms = 400ms expiry).
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    // Request 4 at t=350ms should pass since only Request 2 is active in the window
+    assert!(rate_limit_service.check_rate_limit(key, path, &scope).await.allowed);
+
+    // Request 5 at t=360ms should fail since both Request 2 and Request 4 are active
+    assert!(!rate_limit_service.check_rate_limit(key, path, &scope).await.allowed);
+}


### PR DESCRIPTION
closes #148 
# Reason for the Changes:
- Prevents rate-limit bypass exploits vulnerable in fixed-window limit resets.
- Mitigates denial-of-service risks while ensuring administrative actions are not blocked.
- Exposes detailed endpoint performance metrics for compliance and observation.