### PR TITLE
feat(contracts): add emergency pause circuit breaker to payment router

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -858,6 +858,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "payment-scheduler"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "payment-splitter"
 version = "0.1.0"
 dependencies = [


### PR DESCRIPTION
## Summary

Adds emergency pause/unpause functionality to the payment router contract as a circuit breaker for security incidents.

## Changes

- `KEY_PAUSED` storage key in contract instance storage
- `require_not_paused()` helper — panics with `ContractPaused` when active
- Admin-only `pause()` and `unpause()` with `require_auth()` access control
- `(admin, paused)` and `(admin, unpaused)` events emitted on state change
- `pay()` guarded with `require_not_paused()` check
- `is_paused()` view function
- Full test coverage: initial state, idempotency, auth guards, event assertions, multi-cycle pause/unpause

Closes #174
