### PR TITLE
feat: implement merchant onboarding workflow

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,9 @@
         "axios": "^1.7.0",
         "swagger-ui-express": "^5.0.1",
         "winston": "^3.19.0",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "multer": "^1.4.5-lts.1",
+        "uuid": "^9.0.0"
     },
     "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -38,6 +40,8 @@
         "nodemon": "^3.0.1",
         "prisma": "^5.0.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.2",
+        "@types/multer": "^1.4.11",
+        "@types/uuid": "^9.0.0"
     }
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -82,15 +82,75 @@ model UserProfile {
   updatedAt   DateTime @updatedAt
 }
 
+enum OnboardingStatus {
+  PENDING
+  UNDER_REVIEW
+  APPROVED
+  REJECTED
+}
+
+enum OnboardingStep {
+  BUSINESS_INFO
+  DOCUMENTS_UPLOADED
+  COMPLIANCE_CHECK
+  COMPLETED
+}
+
+enum DocumentType {
+  BUSINESS_REGISTRATION
+  PROOF_OF_ADDRESS
+  OWNER_ID
+  BANK_STATEMENT
+}
+
+enum DocumentStatus {
+  PENDING
+  VERIFIED
+  REJECTED
+}
+
 model Merchant {
-  id              String    @id @default(uuid())
-  merchantId      String    @unique
+  id              String              @id @default(uuid())
+  merchantId      String              @unique
   vaultAddress    String
   settlementAsset String
-  active          Boolean   @default(true)
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
+  active          Boolean             @default(false)
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
   payments        Payment[]
+  onboarding      MerchantOnboarding?
+}
+
+model MerchantOnboarding {
+  id              String           @id @default(uuid())
+  merchantId      String           @unique
+  merchant        Merchant         @relation(fields: [merchantId], references: [merchantId])
+  status          OnboardingStatus @default(PENDING)
+  currentStep     OnboardingStep   @default(BUSINESS_INFO)
+  businessName    String
+  businessEmail   String
+  country         String
+  rejectionReason String?
+  submittedAt     DateTime?
+  reviewedAt      DateTime?
+  reviewedBy      String?
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  documents       MerchantDocument[]
+}
+
+model MerchantDocument {
+  id           String             @id @default(uuid())
+  onboardingId String
+  onboarding   MerchantOnboarding @relation(fields: [onboardingId], references: [id])
+  type         DocumentType
+  status       DocumentStatus     @default(PENDING)
+  storageId    String
+  storageUrl   String
+  mimeType     String
+  size         Int
+  uploadedAt   DateTime           @default(now())
+  verifiedAt   DateTime?
 }
 
 model Payment {

--- a/server/src/controllers/merchant.controller.ts
+++ b/server/src/controllers/merchant.controller.ts
@@ -1,18 +1,107 @@
 import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { DocumentType } from '@prisma/client';
+import prisma from '../utils/prisma';
+import onboardingService from '../services/onboarding.service';
+import { ApiError } from '../middleware/error.middleware';
 
-export const getMerchant = async (req: Request, res: Response, next: NextFunction) => {
+const OnboardSchema = z.object({
+    businessName: z.string().min(1),
+    businessEmail: z.string().email(),
+    country: z.string().min(2),
+    vaultAddress: z.string().min(1),
+    settlementAsset: z.string().min(1),
+});
+
+const ReviewSchema = z.union([
+    z.object({ decision: z.literal('approve') }),
+    z.object({ decision: z.literal('reject'), reason: z.string().min(1) }),
+]);
+
+export const onboard = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        // Logic to fetch merchant details
-        res.status(200).json({ message: 'Merchant details fetched (skeletal)' });
+        const body = OnboardSchema.safeParse(req.body);
+        if (!body.success) throw new ApiError(400, body.error.errors[0].message, 'VALIDATION_ERROR');
+
+        const onboarding = await onboardingService.initiate(body.data);
+        res.status(201).json(onboarding);
     } catch (error) {
         next(error);
     }
 };
 
-export const onboard = async (req: Request, res: Response, next: NextFunction) => {
+export const getMerchant = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        // Logic for merchant onboarding
-        res.status(201).json({ message: 'Merchant onboarded (skeletal)' });
+        const merchant = await prisma.merchant.findUnique({
+            where: { merchantId: req.params.id },
+        });
+        if (!merchant) throw new ApiError(404, 'Merchant not found', 'NOT_FOUND');
+        res.status(200).json(merchant);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const getOnboardingStatus = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const onboarding = await onboardingService.getStatus(req.params.id);
+        res.status(200).json(onboarding);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const uploadDocument = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (!req.file) throw new ApiError(400, 'No file provided', 'MISSING_FILE');
+
+        const type = req.body.type as DocumentType;
+        if (!Object.values(DocumentType).includes(type)) {
+            throw new ApiError(400, `Invalid document type. Must be one of: ${Object.values(DocumentType).join(', ')}`, 'VALIDATION_ERROR');
+        }
+
+        const onboarding = await prisma.merchantOnboarding.findUnique({
+            where: { merchantId: req.params.id },
+        });
+        if (!onboarding) throw new ApiError(404, 'Onboarding record not found', 'NOT_FOUND');
+
+        const doc = await onboardingService.uploadDocument(onboarding.id, req.file, type);
+        res.status(201).json(doc);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const submitOnboarding = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const onboarding = await prisma.merchantOnboarding.findUnique({
+            where: { merchantId: req.params.id },
+        });
+        if (!onboarding) throw new ApiError(404, 'Onboarding record not found', 'NOT_FOUND');
+
+        const updated = await onboardingService.submit(onboarding.id);
+        res.status(200).json(updated);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const reviewOnboarding = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const body = ReviewSchema.safeParse(req.body);
+        if (!body.success) throw new ApiError(400, body.error.errors[0].message, 'VALIDATION_ERROR');
+
+        const onboarding = await prisma.merchantOnboarding.findUnique({
+            where: { merchantId: req.params.id },
+        });
+        if (!onboarding) throw new ApiError(404, 'Onboarding record not found', 'NOT_FOUND');
+
+        const actorId = (req as any).user?.userId ?? 'admin';
+        const updated = body.data.decision === 'approve'
+            ? await onboardingService.approve(onboarding.id, actorId)
+            : await onboardingService.reject(onboarding.id, actorId, body.data.reason);
+
+        res.status(200).json(updated);
     } catch (error) {
         next(error);
     }

--- a/server/src/processors/index.ts
+++ b/server/src/processors/index.ts
@@ -7,11 +7,13 @@ import { processEmail } from './email.processor';
 import { processNotification } from './notification.processor';
 import { processSync } from './sync.processor';
 import { processBlockchainTx } from './blockchain-tx.processor';
+import { processOnboarding } from './onboarding.processor';
 import type {
     EmailJobPayload,
     NotificationJobPayload,
     SyncJobPayload,
     BlockchainTxJobPayload,
+    OnboardingJobPayload,
 } from '../types/job-payloads';
 
 export type ProcessorFn = (data: unknown) => Promise<void>;
@@ -21,6 +23,7 @@ const registry: Map<JobType, ProcessorFn> = new Map([
     [JobType.NOTIFICATION, (d) => processNotification(d as NotificationJobPayload)],
     [JobType.SYNC, (d) => processSync(d as SyncJobPayload)],
     [JobType.BLOCKCHAIN_TX, (d) => processBlockchainTx(d as BlockchainTxJobPayload)],
+    [JobType.ONBOARDING, (d) => processOnboarding(d as OnboardingJobPayload)],
 ]);
 
 export function getProcessor(jobType: JobType): ProcessorFn | undefined {
@@ -31,4 +34,4 @@ export function getAllJobTypes(): JobType[] {
     return Array.from(registry.keys());
 }
 
-export { processEmail, processNotification, processSync, processBlockchainTx };
+export { processEmail, processNotification, processSync, processBlockchainTx, processOnboarding };

--- a/server/src/processors/onboarding.processor.ts
+++ b/server/src/processors/onboarding.processor.ts
@@ -1,0 +1,28 @@
+import type { OnboardingJobPayload } from '../types/job-payloads';
+import onboardingService from '../services/onboarding.service';
+import complianceService from '../services/compliance.service';
+import prisma from '../utils/prisma';
+import logger from '../utils/logger';
+
+export async function processOnboarding(data: OnboardingJobPayload): Promise<void> {
+    const { onboardingId, merchantId } = data;
+
+    const onboarding = await prisma.merchantOnboarding.findUnique({
+        where: { id: onboardingId },
+    });
+
+    if (!onboarding || onboarding.status !== 'UNDER_REVIEW') {
+        logger.warn(`Onboarding job skipped: ${onboardingId} not in UNDER_REVIEW state`);
+        return;
+    }
+
+    const sanctioned = await complianceService.checkSanctions(merchantId);
+    if (sanctioned) {
+        await onboardingService.reject(onboardingId, 'system', 'Automated compliance check: sanctions match');
+        logger.warn(`Onboarding ${onboardingId} auto-rejected: sanctions match`);
+        return;
+    }
+
+    await onboardingService.approve(onboardingId, 'system');
+    logger.info(`Onboarding ${onboardingId} auto-approved`);
+}

--- a/server/src/routes/merchant.routes.ts
+++ b/server/src/routes/merchant.routes.ts
@@ -1,9 +1,16 @@
 import { Router } from 'express';
+import multer from 'multer';
 import * as merchantController from '../controllers/merchant.controller';
+import { adminOnly } from '../middleware/role.middleware';
 
 const router = Router();
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 10 * 1024 * 1024 } });
 
-router.get('/:id', merchantController.getMerchant);
-router.post('/onboard', merchantController.onboard);
+router.post('/onboard',                                          merchantController.onboard);
+router.get('/:id',                                               merchantController.getMerchant);
+router.get('/:id/onboarding',                                    merchantController.getOnboardingStatus);
+router.post('/:id/onboarding/documents', upload.single('file'), merchantController.uploadDocument);
+router.post('/:id/onboarding/submit',                            merchantController.submitOnboarding);
+router.post('/:id/onboarding/review',    adminOnly,              merchantController.reviewOnboarding);
 
 export default router;

--- a/server/src/services/onboarding.service.ts
+++ b/server/src/services/onboarding.service.ts
@@ -1,0 +1,241 @@
+import { DocumentType, MerchantDocument, MerchantOnboarding } from '@prisma/client';
+import prisma from '../utils/prisma';
+import storageService from './storage.service';
+import complianceService from './compliance.service';
+import queueService, { JobType } from './queue.service';
+import { ApiError } from '../middleware/error.middleware';
+import logger from '../utils/logger';
+import { v4 as uuidv4 } from 'uuid';
+
+const REQUIRED_DOCUMENT_TYPES: DocumentType[] = [
+    DocumentType.BUSINESS_REGISTRATION,
+    DocumentType.PROOF_OF_ADDRESS,
+    DocumentType.OWNER_ID,
+    DocumentType.BANK_STATEMENT,
+];
+
+class OnboardingService {
+    /**
+     * Step 1 — POST /merchants/onboard
+     * Creates Merchant (active=false) + MerchantOnboarding atomically.
+     */
+    async initiate(data: {
+        businessName: string;
+        businessEmail: string;
+        country: string;
+        vaultAddress: string;
+        settlementAsset: string;
+    }): Promise<MerchantOnboarding> {
+        const merchantId = uuidv4();
+
+        const [, onboarding] = await prisma.$transaction([
+            prisma.merchant.create({
+                data: {
+                    merchantId,
+                    vaultAddress: data.vaultAddress,
+                    settlementAsset: data.settlementAsset,
+                    active: false,
+                },
+            }),
+            prisma.merchantOnboarding.create({
+                data: {
+                    merchantId,
+                    businessName: data.businessName,
+                    businessEmail: data.businessEmail,
+                    country: data.country,
+                },
+            }),
+        ]);
+
+        logger.info(`Onboarding initiated for merchant ${merchantId}`);
+        return onboarding;
+    }
+
+    /**
+     * Step 2 — POST /merchants/:id/onboarding/documents
+     * Virus-scans, uploads, and records a document.
+     * Advances step to DOCUMENTS_UPLOADED when all four types are present.
+     */
+    async uploadDocument(
+        onboardingId: string,
+        file: Express.Multer.File,
+        type: DocumentType
+    ): Promise<MerchantDocument> {
+        const onboarding = await prisma.merchantOnboarding.findUnique({
+            where: { id: onboardingId },
+        });
+        if (!onboarding) throw new ApiError(404, 'Onboarding record not found', 'NOT_FOUND');
+        if (onboarding.status !== 'PENDING') {
+            throw new ApiError(400, 'Documents can only be uploaded while status is PENDING', 'INVALID_STATE');
+        }
+
+        const clean = await storageService.scanForViruses(file);
+        if (!clean) throw new ApiError(400, 'File failed security scan', 'SECURITY_SCAN_FAILED');
+
+        const stored = await storageService.uploadFile(file, 'merchant-docs');
+
+        const doc = await prisma.merchantDocument.create({
+            data: {
+                onboardingId,
+                type,
+                storageId: stored.id,
+                storageUrl: stored.url,
+                mimeType: stored.mimeType,
+                size: stored.size,
+            },
+        });
+
+        if (await this.allRequiredDocsPresent(onboardingId)) {
+            await prisma.merchantOnboarding.update({
+                where: { id: onboardingId },
+                data: { currentStep: 'DOCUMENTS_UPLOADED' },
+            });
+        }
+
+        return doc;
+    }
+
+    /**
+     * Step 3 — POST /merchants/:id/onboarding/submit
+     * Fast-path sanctions check, then sets UNDER_REVIEW and dispatches job.
+     */
+    async submit(onboardingId: string): Promise<MerchantOnboarding> {
+        const onboarding = await prisma.merchantOnboarding.findUnique({
+            where: { id: onboardingId },
+        });
+        if (!onboarding) throw new ApiError(404, 'Onboarding record not found', 'NOT_FOUND');
+        if (onboarding.status !== 'PENDING') {
+            throw new ApiError(400, 'Onboarding has already been submitted', 'INVALID_STATE');
+        }
+        if (onboarding.currentStep !== 'DOCUMENTS_UPLOADED') {
+            throw new ApiError(400, 'All required documents must be uploaded before submitting', 'MISSING_DOCUMENTS');
+        }
+
+        const sanctioned = await complianceService.checkSanctions(onboarding.merchantId);
+        if (sanctioned) {
+            return this.reject(onboardingId, 'system', 'Sanctions screening match');
+        }
+
+        const updated = await prisma.merchantOnboarding.update({
+            where: { id: onboardingId },
+            data: {
+                status: 'UNDER_REVIEW',
+                currentStep: 'COMPLIANCE_CHECK',
+                submittedAt: new Date(),
+            },
+        });
+
+        await queueService.addJob({
+            type: JobType.ONBOARDING,
+            data: { onboardingId, merchantId: onboarding.merchantId },
+        });
+
+        logger.info(`Onboarding ${onboardingId} submitted for review`);
+        return updated;
+    }
+
+    /**
+     * Step 4a — Approve: activate merchant, verify documents, notify.
+     * Called by the BullMQ processor (actorId='system') or admin endpoint.
+     */
+    async approve(onboardingId: string, actorId: string): Promise<MerchantOnboarding> {
+        const onboarding = await prisma.merchantOnboarding.findUnique({
+            where: { id: onboardingId },
+            include: { documents: true },
+        });
+        if (!onboarding) throw new ApiError(404, 'Onboarding record not found', 'NOT_FOUND');
+        if (onboarding.status !== 'UNDER_REVIEW') {
+            throw new ApiError(400, 'Onboarding is not under review', 'INVALID_STATE');
+        }
+
+        const now = new Date();
+        const [updated] = await prisma.$transaction([
+            prisma.merchantOnboarding.update({
+                where: { id: onboardingId },
+                data: {
+                    status: 'APPROVED',
+                    currentStep: 'COMPLETED',
+                    reviewedAt: now,
+                    reviewedBy: actorId,
+                },
+            }),
+            prisma.merchant.update({
+                where: { merchantId: onboarding.merchantId },
+                data: { active: true },
+            }),
+            prisma.merchantDocument.updateMany({
+                where: { onboardingId },
+                data: { status: 'VERIFIED', verifiedAt: now },
+            }),
+        ]);
+
+        await queueService.addJob({
+            type: JobType.EMAIL,
+            data: {
+                to: onboarding.businessEmail,
+                subject: 'Your merchant account has been approved',
+                templateId: 'merchant_approved',
+                templateData: { businessName: onboarding.businessName },
+            },
+        });
+
+        logger.info(`Onboarding ${onboardingId} approved by ${actorId}`);
+        return updated;
+    }
+
+    /**
+     * Step 4b — Reject: record reason, notify merchant.
+     */
+    async reject(onboardingId: string, actorId: string, reason: string): Promise<MerchantOnboarding> {
+        const onboarding = await prisma.merchantOnboarding.findUnique({
+            where: { id: onboardingId },
+        });
+        if (!onboarding) throw new ApiError(404, 'Onboarding record not found', 'NOT_FOUND');
+
+        const updated = await prisma.merchantOnboarding.update({
+            where: { id: onboardingId },
+            data: {
+                status: 'REJECTED',
+                rejectionReason: reason,
+                reviewedAt: new Date(),
+                reviewedBy: actorId,
+            },
+        });
+
+        await queueService.addJob({
+            type: JobType.EMAIL,
+            data: {
+                to: onboarding.businessEmail,
+                subject: 'Update on your merchant application',
+                templateId: 'merchant_rejected',
+                templateData: { businessName: onboarding.businessName, reason },
+            },
+        });
+
+        logger.info(`Onboarding ${onboardingId} rejected by ${actorId}: ${reason}`);
+        return updated;
+    }
+
+    /**
+     * GET /merchants/:id/onboarding — read current status with documents.
+     */
+    async getStatus(merchantId: string): Promise<MerchantOnboarding & { documents: MerchantDocument[] }> {
+        const onboarding = await prisma.merchantOnboarding.findUnique({
+            where: { merchantId },
+            include: { documents: true },
+        });
+        if (!onboarding) throw new ApiError(404, 'Onboarding record not found', 'NOT_FOUND');
+        return onboarding;
+    }
+
+    private async allRequiredDocsPresent(onboardingId: string): Promise<boolean> {
+        const uploaded = await prisma.merchantDocument.findMany({
+            where: { onboardingId },
+            select: { type: true },
+        });
+        const uploadedTypes = new Set(uploaded.map((d) => d.type));
+        return REQUIRED_DOCUMENT_TYPES.every((t) => uploadedTypes.has(t));
+    }
+}
+
+export default new OnboardingService();

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -6,6 +6,7 @@ import type {
     NotificationJobPayload,
     SyncJobPayload,
     BlockchainTxJobPayload,
+    OnboardingJobPayload,
 } from '../types/job-payloads';
 
 export enum JobType {
@@ -13,13 +14,15 @@ export enum JobType {
     NOTIFICATION = 'NOTIFICATION',
     SYNC = 'SYNC',
     BLOCKCHAIN_TX = 'BLOCKCHAIN_TX',
+    ONBOARDING = 'ONBOARDING',
 }
 
 export type JobPayload =
     | { type: JobType.EMAIL; data: EmailJobPayload }
     | { type: JobType.NOTIFICATION; data: NotificationJobPayload }
     | { type: JobType.SYNC; data: SyncJobPayload }
-    | { type: JobType.BLOCKCHAIN_TX; data: BlockchainTxJobPayload };
+    | { type: JobType.BLOCKCHAIN_TX; data: BlockchainTxJobPayload }
+    | { type: JobType.ONBOARDING; data: OnboardingJobPayload };
 
 const DEFAULT_OPTIONS: JobsOptions = {
     attempts: workerConfig.maxRetries,
@@ -36,12 +39,14 @@ class QueueService {
     private pushQueue: Queue;
     private syncQueue: Queue;
     private blockchainTxQueue: Queue;
+    private onboardingQueue: Queue;
 
     constructor() {
         this.emailQueue = new Queue('email-queue', { connection: connection as any });
         this.pushQueue = new Queue('push-queue', { connection: connection as any });
         this.syncQueue = new Queue('sync-queue', { connection: connection as any });
         this.blockchainTxQueue = new Queue('blockchain-tx-queue', { connection: connection as any });
+        this.onboardingQueue = new Queue('onboarding-queue', { connection: connection as any });
     }
 
     public getEmailQueue(): Queue {
@@ -82,6 +87,8 @@ class QueueService {
                 return this.syncQueue.add(JobType.SYNC, payload.data, finalOptions);
             case JobType.BLOCKCHAIN_TX:
                 return this.blockchainTxQueue.add(JobType.BLOCKCHAIN_TX, payload.data, finalOptions);
+            case JobType.ONBOARDING:
+                return this.onboardingQueue.add(JobType.ONBOARDING, payload.data, finalOptions);
             default:
                 throw new Error(`Unknown job type: ${(payload as JobPayload).type}`);
         }

--- a/server/src/types/job-payloads.ts
+++ b/server/src/types/job-payloads.ts
@@ -41,8 +41,14 @@ export interface BlockchainTxJobPayload {
     transferId?: string;
 }
 
+export interface OnboardingJobPayload {
+    onboardingId: string;
+    merchantId: string;
+}
+
 export type TypedJobPayload =
     | { type: JobType.EMAIL; data: EmailJobPayload }
     | { type: JobType.NOTIFICATION; data: NotificationJobPayload }
     | { type: JobType.SYNC; data: SyncJobPayload }
-    | { type: JobType.BLOCKCHAIN_TX; data: BlockchainTxJobPayload };
+    | { type: JobType.BLOCKCHAIN_TX; data: BlockchainTxJobPayload }
+    | { type: JobType.ONBOARDING; data: OnboardingJobPayload };


### PR DESCRIPTION
 Closes #221 

  Implements all acceptance criteria from issue #221:

  - Schema: MerchantOnboarding and MerchantDocument models with enums OnboardingStatus, OnboardingStep, DocumentType,
  DocumentStatus — Merchant.active defaults to false until approved
  - Document upload: POST /:id/onboarding/documents — multer (10MB), virus scan via storageService, stored as
  MerchantDocument with PENDING status
  - Multi-step flow: BUSINESS_INFO → DOCUMENTS_UPLOADED → COMPLIANCE_CHECK → COMPLETED — step advances automatically as
  documents are uploaded and reviewed
  - Status tracking: MerchantOnboarding records status, currentStep, submittedAt, reviewedAt, reviewedBy,
  rejectionReason — exposed via GET /:id/onboarding
  - Automated approval: onboarding.processor.ts BullMQ job runs sanctions check on submission — auto-approves or
  auto-rejects without human intervention; activates Merchant.active = true on approval
  - Admin override: POST /:id/onboarding/review (admin only) — manual approve/reject with reason
  - Notifications: email job dispatched on approval and rejection via existing queue infrastructure