### PR TITLE
feat: implement API versioning system with deprecation and negotiatio…

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -11,8 +11,8 @@ use crate::{
     config::Config,
     http::{
         admin, analytics, audit, auth, batches, currency, disputes, files, health, identity, jobs,
-        metrics as metrics_http, notifications, payments, payouts, profiles, transfers, version as version_http,
-        withdrawals, webhooks,
+        metrics as metrics_http, notifications, payments, payouts, profiles, transfers,
+        version as version_http, versioning as versioning_http, withdrawals, webhooks,
     },
     http::{
         get_reconciliation_audit_log, get_reconciliations, resolve_reconciliation,
@@ -304,6 +304,27 @@ pub async fn create_app(
         );
 
     // =========================================================================
+    // API versioning system routes (public, no auth)
+    // =========================================================================
+    let versioning_routes = Router::new()
+        .route(
+            "/versioning/negotiate",
+            get(versioning_http::negotiate_version),
+        )
+        .route(
+            "/versioning/deprecations",
+            get(versioning_http::list_deprecations),
+        )
+        .route(
+            "/versioning/:version/capabilities",
+            get(versioning_http::get_version_capabilities),
+        )
+        .route(
+            "/versioning/compatibility/:version",
+            get(versioning_http::check_compatibility),
+        );
+
+    // =========================================================================
     // Anchor & public routes
     // =========================================================================
     let anchor_routes =
@@ -325,6 +346,8 @@ pub async fn create_app(
         .nest("/api/v2", api_v2)
         // Version documentation (public)
         .nest("/api", version_doc_routes)
+        // API versioning system (public)
+        .nest("/api", versioning_routes)
         // Legacy unversioned public routes (backward compat)
         .merge(public_routes)
         .with_state(services)

--- a/backend/src/http/mod.rs
+++ b/backend/src/http/mod.rs
@@ -18,6 +18,7 @@ pub mod profiles;
 pub mod reconciliation;
 pub mod transfers;
 pub mod version;
+pub mod versioning;
 pub mod withdrawals;
 pub mod webhooks;
 
@@ -44,5 +45,6 @@ pub use reconciliation::{
 };
 pub use transfers::*;
 pub use version::*;
+pub use versioning::*;
 pub use withdrawals::*;
 pub use webhooks::*;

--- a/backend/src/http/version.rs
+++ b/backend/src/http/version.rs
@@ -103,7 +103,7 @@ fn v2_info() -> VersionInfo {
 pub async fn list_versions() -> Json<VersionListResponse> {
     Json(VersionListResponse {
         versions: vec![v1_info(), v2_info()],
-        current_version: "v1",
+        current_version: "v2",
         latest_version: "v2",
     })
 }

--- a/backend/src/http/versioning.rs
+++ b/backend/src/http/versioning.rs
@@ -1,0 +1,499 @@
+use axum::{
+    extract::{Path, Query},
+    Json,
+};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::{api_error::ApiError, middleware::versioning::ApiVersion};
+
+// ---------------------------------------------------------------------------
+// Request / query types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct NegotiateQuery {
+    /// The version the client would like to use (e.g. "v1", "v2", "1", "2")
+    pub requested: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct NegotiationResponse {
+    pub recommended_version: String,
+    pub requested_version: Option<String>,
+    pub is_deprecated: bool,
+    pub sunset_date: Option<String>,
+    pub migration_guide_url: Option<String>,
+    pub available_versions: Vec<String>,
+    pub latest_version: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeprecationNotice {
+    pub version: String,
+    pub deprecated_since: &'static str,
+    pub sunset_date: &'static str,
+    pub migration_guide_url: &'static str,
+    pub reason: &'static str,
+    pub affected_endpoints: Vec<&'static str>,
+    pub replacement_version: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeprecationListResponse {
+    pub deprecations: Vec<DeprecationNotice>,
+    pub total: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EndpointInfo {
+    pub method: &'static str,
+    pub path: &'static str,
+    pub description: &'static str,
+    pub added_in: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated_in: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VersionCapabilities {
+    pub version: String,
+    pub status: &'static str,
+    pub endpoints: Vec<EndpointInfo>,
+    pub features: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CompatibilityInfo {
+    pub version: String,
+    pub is_supported: bool,
+    pub is_deprecated: bool,
+    pub status: &'static str,
+    pub sunset_date: Option<&'static str>,
+    /// Number of days until the version is removed; negative means already past sunset.
+    pub days_until_sunset: Option<i64>,
+    pub recommended_version: String,
+    pub upgrade_required_by: Option<&'static str>,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// GET /api/versioning/negotiate
+///
+/// Given an optional `requested` query parameter, returns the recommended API
+/// version alongside deprecation details so clients can make an informed choice.
+///
+/// Example: `GET /api/versioning/negotiate?requested=v1`
+pub async fn negotiate_version(
+    Query(query): Query<NegotiateQuery>,
+) -> Json<NegotiationResponse> {
+    let available = vec!["v1".to_string(), "v2".to_string()];
+    let latest = ApiVersion::latest();
+
+    let (requested_str, is_deprecated, sunset_date, migration_guide_url) =
+        match query.requested.as_deref() {
+            Some(req) => match ApiVersion::from_header_value(req) {
+                Some(version) => (
+                    Some(version.as_str().to_string()),
+                    version.is_deprecated(),
+                    version.sunset_date().map(String::from),
+                    version.migration_guide_url().map(String::from),
+                ),
+                None => (Some(req.to_string()), false, None, None),
+            },
+            None => (None, false, None, None),
+        };
+
+    Json(NegotiationResponse {
+        recommended_version: latest.as_str().to_string(),
+        requested_version: requested_str,
+        is_deprecated,
+        sunset_date,
+        migration_guide_url,
+        available_versions: available,
+        latest_version: latest.as_str().to_string(),
+    })
+}
+
+/// GET /api/versioning/deprecations
+///
+/// Returns all active deprecation notices so clients can proactively plan
+/// migrations without waiting for sunset.
+pub async fn list_deprecations() -> Json<DeprecationListResponse> {
+    let deprecations = build_deprecation_notices();
+    let total = deprecations.len();
+    Json(DeprecationListResponse { deprecations, total })
+}
+
+/// GET /api/versioning/:version/capabilities
+///
+/// Returns the full list of endpoints and feature flags available in the
+/// requested API version.  Useful for feature detection and documentation.
+pub async fn get_version_capabilities(
+    Path(version): Path<String>,
+) -> Result<Json<VersionCapabilities>, ApiError> {
+    match version.as_str() {
+        "v1" => Ok(Json(v1_capabilities())),
+        "v2" => Ok(Json(v2_capabilities())),
+        _ => Err(ApiError::NotFound(format!(
+            "API version '{}' not found. Supported versions: v1, v2",
+            version
+        ))),
+    }
+}
+
+/// GET /api/versioning/compatibility/:version
+///
+/// Returns lifecycle status for the given version, including how many days
+/// remain before sunset, so clients can build their own upgrade-urgency logic.
+pub async fn check_compatibility(
+    Path(version): Path<String>,
+) -> Result<Json<CompatibilityInfo>, ApiError> {
+    let api_version =
+        ApiVersion::from_header_value(&version).ok_or_else(|| {
+            ApiError::NotFound(format!(
+                "API version '{}' not found. Supported versions: v1, v2",
+                version
+            ))
+        })?;
+
+    let days_until_sunset = api_version
+        .sunset_date()
+        .and_then(|s| chrono::DateTime::parse_from_rfc2822(s).ok())
+        .map(|sunset| {
+            let sunset_utc = sunset.with_timezone(&Utc);
+            sunset_utc.signed_duration_since(Utc::now()).num_days()
+        });
+
+    let (status, is_deprecated) = if api_version.is_deprecated() {
+        ("deprecated", true)
+    } else {
+        ("current", false)
+    };
+
+    Ok(Json(CompatibilityInfo {
+        version: api_version.as_str().to_string(),
+        is_supported: true,
+        is_deprecated,
+        status,
+        sunset_date: api_version.sunset_date(),
+        days_until_sunset,
+        recommended_version: ApiVersion::latest().as_str().to_string(),
+        upgrade_required_by: api_version.sunset_date(),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Data helpers
+// ---------------------------------------------------------------------------
+
+fn build_deprecation_notices() -> Vec<DeprecationNotice> {
+    vec![DeprecationNotice {
+        version: "v1".to_string(),
+        deprecated_since: "2026-05-01",
+        sunset_date: "2027-01-01",
+        migration_guide_url: "https://docs.blinks.app/api/migration/v1-to-v2",
+        reason: "v2 introduces payment dispute management, enhanced analytics, and improved \
+                 response schemas. v1 will no longer receive feature updates.",
+        affected_endpoints: vec![
+            "POST /api/v1/payments",
+            "GET  /api/v1/payments/:id",
+            "GET  /api/v1/payments/:id/status",
+            "POST /api/v1/transfers",
+            "POST /api/v1/withdrawals",
+        ],
+        replacement_version: "v2".to_string(),
+    }]
+}
+
+fn v1_capabilities() -> VersionCapabilities {
+    VersionCapabilities {
+        version: "v1".to_string(),
+        status: "deprecated",
+        features: vec![
+            "payments",
+            "payouts",
+            "transfers",
+            "withdrawals",
+            "identity",
+            "notifications",
+            "profiles",
+            "files",
+            "batches",
+            "audit-logs",
+            "analytics",
+            "reconciliation",
+            "webhooks",
+        ],
+        endpoints: vec![
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v1/payments",
+                description: "Create a payment",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v1/payments/:id",
+                description: "Get payment by ID",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v1/payments/:id/status",
+                description: "Get payment status",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v1/transfers",
+                description: "Create a transfer",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v1/transfers/:id",
+                description: "Get transfer by ID",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v1/withdrawals",
+                description: "Create a withdrawal",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v1/payouts",
+                description: "Create a payout",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v1/identity/users",
+                description: "Create a user identity",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v1/identity/users/me",
+                description: "Get current user",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v1/notifications",
+                description: "List notifications",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v1/audit-logs",
+                description: "List audit logs (admin)",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+        ],
+    }
+}
+
+fn v2_capabilities() -> VersionCapabilities {
+    VersionCapabilities {
+        version: "v2".to_string(),
+        status: "current",
+        features: vec![
+            "payments",
+            "payment-disputes",
+            "payouts",
+            "transfers",
+            "withdrawals",
+            "identity",
+            "notifications",
+            "profiles",
+            "files",
+            "batches",
+            "audit-logs",
+            "analytics",
+            "reconciliation",
+            "webhooks",
+            "enhanced-caching",
+            "version-analytics",
+        ],
+        endpoints: vec![
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v2/payments",
+                description: "Create a payment (response includes dispute_eligible field)",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v2/payments/:id",
+                description: "Get payment by ID (response includes active_dispute field)",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v2/payments/:id/status",
+                description: "Get payment status",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v2/payments/:payment_id/disputes",
+                description: "File a dispute for a payment",
+                added_in: "v2",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v2/payments/:payment_id/disputes",
+                description: "List disputes for a payment",
+                added_in: "v2",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v2/disputes",
+                description: "List all disputes (admin)",
+                added_in: "v2",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v2/disputes/me",
+                description: "List disputes for current user",
+                added_in: "v2",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v2/disputes/:id",
+                description: "Get dispute by ID",
+                added_in: "v2",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "PATCH",
+                path: "/api/v2/disputes/:id/status",
+                description: "Update dispute status",
+                added_in: "v2",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v2/disputes/:id/evidence",
+                description: "Add evidence to a dispute",
+                added_in: "v2",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v2/transfers",
+                description: "Create a transfer",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v2/withdrawals",
+                description: "Create a withdrawal",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v2/payouts",
+                description: "Create a payout",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "POST",
+                path: "/api/v2/identity/users",
+                description: "Create a user identity",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v2/notifications",
+                description: "List notifications",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+            EndpointInfo {
+                method: "GET",
+                path: "/api/v2/audit-logs",
+                description: "List audit logs (admin)",
+                added_in: "v1",
+                deprecated_in: None,
+            },
+        ],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_v1_capabilities_status_is_deprecated() {
+        let caps = v1_capabilities();
+        assert_eq!(caps.status, "deprecated");
+    }
+
+    #[test]
+    fn test_v2_capabilities_includes_disputes() {
+        let caps = v2_capabilities();
+        assert!(caps.features.contains(&"payment-disputes"));
+        assert!(caps
+            .endpoints
+            .iter()
+            .any(|e| e.path.contains("disputes")));
+    }
+
+    #[test]
+    fn test_v2_dispute_endpoints_added_in_v2() {
+        let caps = v2_capabilities();
+        for ep in caps.endpoints.iter().filter(|e| e.path.contains("disputes")) {
+            assert_eq!(ep.added_in, "v2");
+        }
+    }
+
+    #[test]
+    fn test_deprecation_notices_cover_v1() {
+        let notices = build_deprecation_notices();
+        assert!(!notices.is_empty());
+        assert_eq!(notices[0].version, "v1");
+        assert_eq!(notices[0].replacement_version, "v2");
+    }
+
+    #[test]
+    fn test_unknown_version_returns_none() {
+        assert!(ApiVersion::from_header_value("v99").is_none());
+    }
+}

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -11,4 +11,4 @@ pub use auth::*;
 pub use metrics::*;
 pub use request_id::*;
 pub use role_guard::*;
-pub use versioning::version_middleware;
+pub use versioning::{version_middleware, ApiVersion, ApiVersionExtension};

--- a/backend/src/middleware/versioning.rs
+++ b/backend/src/middleware/versioning.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::Request,
-    http::{header::HeaderName, HeaderValue},
+    http::{header::HeaderName, HeaderMap, HeaderValue},
     middleware::Next,
     response::Response,
 };
@@ -21,12 +21,19 @@ impl ApiVersion {
         }
     }
 
+    pub fn as_numeric(&self) -> u32 {
+        match self {
+            ApiVersion::V1 => 1,
+            ApiVersion::V2 => 2,
+        }
+    }
+
     /// Whether this version is deprecated
     pub fn is_deprecated(&self) -> bool {
         matches!(self, ApiVersion::V1)
     }
 
-    /// Sunset date for deprecated versions (RFC 7231 HTTP-date format)
+    /// Sunset date for deprecated versions (RFC 2822 HTTP-date format)
     pub fn sunset_date(&self) -> Option<&'static str> {
         match self {
             ApiVersion::V1 => Some("Sun, 01 Jan 2027 00:00:00 GMT"),
@@ -50,37 +57,60 @@ impl ApiVersion {
             _ => None,
         }
     }
+
+    /// Parse from a header or query-string value — accepts "v1", "v2", "1", "2"
+    pub fn from_header_value(value: &str) -> Option<Self> {
+        match value.trim() {
+            "v1" | "1" => Some(ApiVersion::V1),
+            "v2" | "2" => Some(ApiVersion::V2),
+            _ => None,
+        }
+    }
+
+    /// The latest stable API version
+    pub fn latest() -> Self {
+        ApiVersion::V2
+    }
 }
 
-/// Axum middleware that injects API version headers and records version usage analytics.
-///
-/// Adds the following response headers:
-/// - `X-API-Version`: the resolved version (e.g. "v1")
-/// - `Deprecation`: RFC 8594 deprecation header (if version is deprecated)
-/// - `Sunset`: date after which the version will be removed (if deprecated)
-/// - `Link`: link to migration guide (if deprecated)
-pub async fn version_middleware(request: Request, next: Next) -> Response {
-    // Extract version from the request path (e.g. /api/v1/... → "v1")
-    let path = request.uri().path().to_string();
-    let version = extract_version_from_path(&path);
+/// Stored in request extensions so downstream handlers can inspect the active version.
+#[derive(Debug, Clone, Copy)]
+pub struct ApiVersionExtension(pub ApiVersion);
 
-    // Record version usage analytics via Prometheus
+/// Axum middleware that resolves the API version, stores it in request extensions,
+/// and injects version/deprecation headers into responses.
+///
+/// Version resolution order:
+///   1. Path segment (`/api/v2/...`)
+///   2. Request header (`X-API-Version`, `Accept-Version`, or `API-Version`)
+///   3. Default to V1 for backward compatibility
+///
+/// Response headers added:
+///   - `X-API-Version`   — resolved version string
+///   - `Deprecation`     — "true" when the version is deprecated (RFC 8594)
+///   - `Sunset`          — removal date for deprecated versions
+///   - `Link`            — URL to the migration guide
+///   - `Warning`         — RFC 7234 299 warning with human-readable deprecation notice
+pub async fn version_middleware(mut request: Request, next: Next) -> Response {
+    let path = request.uri().path().to_string();
+
+    let version = extract_version_from_path(&path)
+        .or_else(|| extract_version_from_headers(request.headers()))
+        .unwrap_or(ApiVersion::V1);
+
+    // Make the resolved version available to handlers
+    request.extensions_mut().insert(ApiVersionExtension(version));
+
     MetricsService::record_api_version_usage(version.as_str(), &path);
 
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
 
-    // Always inject the resolved version
     if let Ok(val) = HeaderValue::from_str(version.as_str()) {
-        headers.insert(
-            HeaderName::from_static("x-api-version"),
-            val,
-        );
+        headers.insert(HeaderName::from_static("x-api-version"), val);
     }
 
-    // Inject deprecation headers when applicable
     if version.is_deprecated() {
-        // RFC 8594 Deprecation header — use a boolean "true" value
         headers.insert(
             HeaderName::from_static("deprecation"),
             HeaderValue::from_static("true"),
@@ -99,9 +129,22 @@ pub async fn version_middleware(request: Request, next: Next) -> Response {
             }
         }
 
-        tracing::debug!(
+        // RFC 7234 §5.5 Warning header — code 299 = "Miscellaneous persistent warning"
+        let warning = format!(
+            r#"299 - "API {} is deprecated and will be removed on {}. Migrate to {}: {}""#,
+            version.as_str(),
+            version.sunset_date().unwrap_or("TBD"),
+            ApiVersion::latest().as_str(),
+            version.migration_guide_url().unwrap_or("https://docs.blinks.app/api"),
+        );
+        if let Ok(val) = HeaderValue::from_str(&warning) {
+            headers.insert(HeaderName::from_static("warning"), val);
+        }
+
+        tracing::warn!(
             api_version = version.as_str(),
             path = %path,
+            sunset = version.sunset_date().unwrap_or("unknown"),
             "Deprecated API version used"
         );
     }
@@ -109,17 +152,26 @@ pub async fn version_middleware(request: Request, next: Next) -> Response {
     response
 }
 
-/// Extract the API version from a URL path.
-/// Looks for a path segment matching "v1", "v2", etc.
-/// Falls back to V1 if no version segment is found (backward compatibility).
-fn extract_version_from_path(path: &str) -> ApiVersion {
+fn extract_version_from_path(path: &str) -> Option<ApiVersion> {
     for segment in path.split('/') {
         if let Some(version) = ApiVersion::from_path_segment(segment) {
-            return version;
+            return Some(version);
         }
     }
-    // Default to V1 for unversioned paths (backward compat)
-    ApiVersion::V1
+    None
+}
+
+fn extract_version_from_headers(headers: &HeaderMap) -> Option<ApiVersion> {
+    for header_name in &["x-api-version", "accept-version", "api-version"] {
+        if let Some(val) = headers.get(*header_name) {
+            if let Ok(s) = val.to_str() {
+                if let Some(v) = ApiVersion::from_header_value(s) {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -128,9 +180,9 @@ mod tests {
 
     #[test]
     fn test_extract_version_from_path() {
-        assert_eq!(extract_version_from_path("/api/v1/payments"), ApiVersion::V1);
-        assert_eq!(extract_version_from_path("/api/v2/payments"), ApiVersion::V2);
-        assert_eq!(extract_version_from_path("/health"), ApiVersion::V1); // default
+        assert_eq!(extract_version_from_path("/api/v1/payments"), Some(ApiVersion::V1));
+        assert_eq!(extract_version_from_path("/api/v2/payments"), Some(ApiVersion::V2));
+        assert_eq!(extract_version_from_path("/health"), None);
     }
 
     #[test]
@@ -143,5 +195,32 @@ mod tests {
     fn test_sunset_date() {
         assert!(ApiVersion::V1.sunset_date().is_some());
         assert!(ApiVersion::V2.sunset_date().is_none());
+    }
+
+    #[test]
+    fn test_from_header_value() {
+        assert_eq!(ApiVersion::from_header_value("v1"), Some(ApiVersion::V1));
+        assert_eq!(ApiVersion::from_header_value("v2"), Some(ApiVersion::V2));
+        assert_eq!(ApiVersion::from_header_value("1"), Some(ApiVersion::V1));
+        assert_eq!(ApiVersion::from_header_value("2"), Some(ApiVersion::V2));
+        assert_eq!(ApiVersion::from_header_value("  v2  "), Some(ApiVersion::V2));
+        assert_eq!(ApiVersion::from_header_value("v3"), None);
+        assert_eq!(ApiVersion::from_header_value(""), None);
+    }
+
+    #[test]
+    fn test_latest_is_v2() {
+        assert_eq!(ApiVersion::latest(), ApiVersion::V2);
+    }
+
+    #[test]
+    fn test_as_numeric() {
+        assert_eq!(ApiVersion::V1.as_numeric(), 1);
+        assert_eq!(ApiVersion::V2.as_numeric(), 2);
+    }
+
+    #[test]
+    fn test_version_ordering() {
+        assert!(ApiVersion::V1 < ApiVersion::V2);
     }
 }


### PR DESCRIPTION
PR #171  Backend: Add API Versioning System

## Overview

Implements a comprehensive API versioning system with backward compatibility, deprecation warnings, version negotiation, and per-version documentation as described in issue #171.

---

## Changes

### `backend/src/middleware/versioning.rs` — enhanced

- Added `ApiVersionExtension` stored in request extensions, giving any downstream handler access to the resolved API version without re-parsing the path
- Added header-based version detection as a fallback (`X-API-Version`, `Accept-Version`, `API-Version` request headers) when no version segment is present in the path
- Added `ApiVersion::from_header_value()`, `ApiVersion::as_numeric()`, and `ApiVersion::latest()` methods
- Deprecated v1 responses now carry five headers:
  - `X-API-Version: v1`
  - `Deprecation: true` (RFC 8594)
  - `Sunset: Sun, 01 Jan 2027 00:00:00 GMT`
  - `Link: <https://docs.blinks.app/api/migration/v1-to-v2>; rel="deprecation"`
  - `Warning: 299 - "API v1 is deprecated..."` (RFC 7234)
- Upgraded deprecation log level from `debug` → `warn`
- Exports `ApiVersion` and `ApiVersionExtension` from the middleware crate root

### `backend/src/http/versioning.rs` — new file

Four public, auth-free HTTP handlers:

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/versioning/negotiate` | Returns the recommended version for a given `?requested=` query param; includes deprecation info if the requested version is deprecated |
| `GET` | `/api/versioning/deprecations` | Full list of active deprecation notices with affected endpoints, sunset date, reason, and migration URL |
| `GET` | `/api/versioning/:version/capabilities` | Complete endpoint catalogue and feature list for `v1` or `v2` |
| `GET` | `/api/versioning/compatibility/:version` | Lifecycle status for a version, including computed `days_until_sunset` based on the current date |

### `backend/src/http/version.rs` — bug fix

- `current_version` in `GET /api/versions` was incorrectly returning `"v1"`. Corrected to `"v2"`.

### `backend/src/http/mod.rs`

- Registered `pub mod versioning` and `pub use versioning::*`

### `backend/src/middleware/mod.rs`

- Expanded re-export to include `ApiVersion` and `ApiVersionExtension` alongside `version_middleware`

### `backend/src/app.rs`

- Imported `versioning as versioning_http` from the `http` module
- Added `versioning_routes` router nested at `/api` with all four new endpoints

---

## Acceptance Criteria

- [x] Support multiple API versions simultaneously — `/api/v1` and `/api/v2` routes serve independent handler trees
- [x] Implement version deprecation warnings — middleware injects `Deprecation`, `Sunset`, `Link`, and `Warning` headers on all v1 responses
- [x] Add version-specific documentation — `/api/versioning/:version/capabilities` returns full endpoint and feature listings per version
- [x] Include migration guides for version updates — `/api/versions/v1/migration` returns step-by-step guide; `/api/versioning/deprecations` lists all notices with migration URLs

---

## Test Plan

- [ ] `GET /api/versioning/negotiate?requested=v1` → `recommended_version: "v2"`, `is_deprecated: true`
- [ ] `GET /api/versioning/negotiate?requested=v2` → `is_deprecated: false`
- [ ] `GET /api/versioning/negotiate` (no param) → `recommended_version: "v2"`
- [ ] `GET /api/versioning/deprecations` → v1 notice present with affected endpoints and sunset date
- [ ] `GET /api/versioning/v1/capabilities` → `status: "deprecated"`, no dispute endpoints
- [ ] `GET /api/versioning/v2/capabilities` → `status: "current"`, dispute endpoints present
- [ ] `GET /api/versioning/compatibility/v1` → `is_deprecated: true`, positive `days_until_sunset`
- [ ] `GET /api/versioning/compatibility/v2` → `is_deprecated: false`, `days_until_sunset: null`
- [ ] `GET /api/versioning/compatibility/v99` → 404 Not Found
- [ ] Any `GET /api/v1/*` response includes all five deprecation headers
- [ ] Any `GET /api/v2/*` response has `X-API-Version: v2` and no deprecation headers
- [ ] `GET /api/versions` → `current_version: "v2"` (bug fix verified)
- [ ] Request with `X-API-Version: v1` header (path has no version segment) → deprecation headers injected

---

Closes #171 
