### PR TITLE
feat(contracts): fix #160 payment scheduler and #177 price oracle

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -174,6 +174,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cross-chain-bridge"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +439,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
+name = "escrow-contract"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +454,13 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "example-contract"
 version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "fee-distribution"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]
@@ -501,6 +522,13 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "governance"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "group"
@@ -673,6 +701,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loyalty-points"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,7 +715,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "merchant-vault"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]
@@ -773,11 +808,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "payment-analytics"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "payment-approval"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "payment-escrow"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "payment-history"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "payment-insurance"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "payment-limits"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "payment-recovery"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "payment-router"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk",
  "soroban-token-sdk",
+]
+
+[[package]]
+name = "payment-scheduler"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "payment-splitter"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "payment-tagging"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -813,6 +918,13 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "price-oracle"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -890,6 +1002,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "registry-contract"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1341,6 +1460,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subscription-payments"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1545,13 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "upgradeable-proxy"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "user-identity-contract"

--- a/contracts/payment-history/Cargo.toml
+++ b/contracts/payment-history/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "payment-history"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true

--- a/contracts/payment-scheduler/src/lib.rs
+++ b/contracts/payment-scheduler/src/lib.rs
@@ -1,53 +1,24 @@
 #![no_std]
 
-//! # Payment Scheduler Contract
-//!
-//! Schedules one-time and recurring payments for future execution.
-//!
-//! ## Lifecycle
-//! 1. Admin calls `initialize`.
-//! 2. A payer calls `schedule` to create a one-time or recurring schedule.
-//! 3. Anyone calls `execute` once the due ledger is reached.
-//! 4. The payer (or admin) may call `cancel` before execution.
-//! 5. The payer may call `modify` to update amount/interval before execution.
-//!
-//! ## Access Control
-//! - Admin: initialize, pause/unpause, upgrade.
-//! - Payer: schedule, cancel, modify their own schedules.
-//! - Anyone: execute a due schedule (permissionless keeper).
-
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short,
-    token::Client as TokenClient, Address, Env,
+    token::Client as TokenClient, Address, Env, Symbol,
 };
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const TTL_THRESHOLD: u32 = 100_000;
-const TTL_EXTEND: u32 = 6_307_200;
+const INSTANCE_TTL_THRESHOLD: u32 = 100_000;
+const INSTANCE_TTL_EXTEND: u32 = 6_307_200;
 const PERSISTENT_TTL_THRESHOLD: u32 = 50_000;
 const PERSISTENT_TTL_EXTEND: u32 = 3_153_600;
 
-// ---------------------------------------------------------------------------
-// Storage keys
-// ---------------------------------------------------------------------------
-
 #[contracttype]
 #[derive(Clone)]
-enum Key {
+enum DataKey {
     Admin,
     Paused,
     Counter,
     Schedule(u64),
 }
 
-// ---------------------------------------------------------------------------
-// Data types
-// ---------------------------------------------------------------------------
-
-/// Whether a schedule fires once or repeats.
 #[contracttype]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ScheduleKind {
@@ -55,7 +26,6 @@ pub enum ScheduleKind {
     Recurring = 2,
 }
 
-/// Lifecycle state of a schedule.
 #[contracttype]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ScheduleStatus {
@@ -64,7 +34,6 @@ pub enum ScheduleStatus {
     Cancelled = 3,
 }
 
-/// A payment schedule entry.
 #[contracttype]
 #[derive(Clone)]
 pub struct Schedule {
@@ -72,18 +41,13 @@ pub struct Schedule {
     pub recipient: Address,
     pub token: Address,
     pub amount: i128,
-    /// Ledger at which the next execution is due.
-    pub execute_at: u32,
-    /// For recurring schedules: ledgers between executions. 0 for one-time.
-    pub interval_ledgers: u32,
+    pub execute_after: u64,
+    pub interval_seconds: u64,
     pub kind: ScheduleKind,
     pub status: ScheduleStatus,
     pub executions: u32,
+    pub max_executions: u32,
 }
-
-// ---------------------------------------------------------------------------
-// Errors
-// ---------------------------------------------------------------------------
 
 #[contracterror]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -97,32 +61,39 @@ pub enum Error {
     NotDue = 7,
     InvalidAmount = 8,
     InvalidInterval = 9,
-    InvalidExecuteAt = 10,
+    InvalidExecuteAfter = 10,
+    InvalidExecutionLimit = 11,
+    ArithmeticOverflow = 12,
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 fn bump_instance(env: &Env) {
     env.storage()
         .instance()
-        .extend_ttl(TTL_THRESHOLD, TTL_EXTEND);
+        .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND);
 }
 
-fn bump_persistent(env: &Env, key: &Key) {
-    env.storage()
-        .persistent()
-        .extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
+fn bump_schedule(env: &Env, id: u64) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::Schedule(id),
+        PERSISTENT_TTL_THRESHOLD,
+        PERSISTENT_TTL_EXTEND,
+    );
+}
+
+fn require_initialized(env: &Env) {
+    if !env.storage().instance().has(&DataKey::Admin) {
+        panic_with_error!(env, Error::NotInitialized);
+    }
 }
 
 fn require_not_paused(env: &Env) {
-    if env
+    require_initialized(env);
+    let paused = env
         .storage()
         .instance()
-        .get(&Key::Paused)
-        .unwrap_or(false)
-    {
+        .get(&DataKey::Paused)
+        .unwrap_or(false);
+    if paused {
         panic_with_error!(env, Error::ContractPaused);
     }
 }
@@ -131,273 +102,328 @@ fn require_admin(env: &Env) -> Address {
     let admin: Address = env
         .storage()
         .instance()
-        .get(&Key::Admin)
+        .get(&DataKey::Admin)
         .unwrap_or_else(|| panic_with_error!(env, Error::NotInitialized));
     admin.require_auth();
     admin
 }
 
+fn checked_reserved(env: &Env, amount: i128, executions: u32) -> i128 {
+    if amount <= 0 {
+        panic_with_error!(env, Error::InvalidAmount);
+    }
+    amount
+        .checked_mul(executions as i128)
+        .unwrap_or_else(|| panic_with_error!(env, Error::ArithmeticOverflow))
+}
+
+fn validate_schedule(
+    env: &Env,
+    amount: i128,
+    execute_after: u64,
+    interval_seconds: u64,
+    kind: ScheduleKind,
+    max_executions: u32,
+) {
+    if amount <= 0 {
+        panic_with_error!(env, Error::InvalidAmount);
+    }
+    if execute_after < env.ledger().timestamp() {
+        panic_with_error!(env, Error::InvalidExecuteAfter);
+    }
+    match kind {
+        ScheduleKind::OneTime => {
+            if max_executions != 1 || interval_seconds != 0 {
+                panic_with_error!(env, Error::InvalidExecutionLimit);
+            }
+        }
+        ScheduleKind::Recurring => {
+            if interval_seconds == 0 {
+                panic_with_error!(env, Error::InvalidInterval);
+            }
+            if max_executions == 0 {
+                panic_with_error!(env, Error::InvalidExecutionLimit);
+            }
+        }
+    }
+}
+
 fn load_schedule(env: &Env, id: u64) -> Schedule {
+    let schedule = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Schedule(id))
+        .unwrap_or_else(|| panic_with_error!(env, Error::ScheduleNotFound));
+    bump_schedule(env, id);
+    schedule
+}
+
+fn save_schedule(env: &Env, id: u64, schedule: &Schedule) {
     env.storage()
         .persistent()
-        .get(&Key::Schedule(id))
-        .unwrap_or_else(|| panic_with_error!(env, Error::ScheduleNotFound))
+        .set(&DataKey::Schedule(id), schedule);
+    bump_schedule(env, id);
 }
 
-fn save_schedule(env: &Env, id: u64, s: &Schedule) {
-    env.storage().persistent().set(&Key::Schedule(id), s);
-    bump_persistent(env, &Key::Schedule(id));
+fn remaining_executions(schedule: &Schedule) -> u32 {
+    schedule.max_executions.saturating_sub(schedule.executions)
 }
 
-// ---------------------------------------------------------------------------
-// Contract
-// ---------------------------------------------------------------------------
+fn emit(env: &Env, action: Symbol, id: u64) {
+    env.events()
+        .publish((symbol_short!("schedule"), action), id);
+}
 
 #[contract]
 pub struct PaymentScheduler;
 
 #[contractimpl]
 impl PaymentScheduler {
-    // -----------------------------------------------------------------------
-    // Initialisation
-    // -----------------------------------------------------------------------
-
     pub fn initialize(env: Env, admin: Address) {
-        if env.storage().instance().has(&Key::Admin) {
+        if env.storage().instance().has(&DataKey::Admin) {
             panic_with_error!(env, Error::AlreadyInitialized);
         }
         admin.require_auth();
-        env.storage().instance().set(&Key::Admin, &admin);
-        env.storage().instance().set(&Key::Paused, &false);
-        env.storage().instance().set(&Key::Counter, &0u64);
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().set(&DataKey::Counter, &0u64);
         bump_instance(&env);
     }
 
-    // -----------------------------------------------------------------------
-    // Schedule creation
-    // -----------------------------------------------------------------------
-
-    /// Create a payment schedule.
-    ///
-    /// * `payer`            – address that will be charged (must sign)
-    /// * `recipient`        – address that receives the payment
-    /// * `token`            – token contract address
-    /// * `amount`           – amount per execution (> 0)
-    /// * `execute_at`       – ledger at which first execution is due (>= current)
-    /// * `interval_ledgers` – for recurring: ledgers between executions (> 0); ignored for one-time
-    /// * `kind`             – `OneTime` or `Recurring`
-    ///
-    /// Returns the new schedule ID.
     pub fn schedule(
         env: Env,
         payer: Address,
         recipient: Address,
         token: Address,
         amount: i128,
-        execute_at: u32,
-        interval_ledgers: u32,
+        execute_after: u64,
+        interval_seconds: u64,
         kind: ScheduleKind,
+        max_executions: u32,
     ) -> u64 {
         require_not_paused(&env);
-        bump_instance(&env);
-
         payer.require_auth();
+        validate_schedule(
+            &env,
+            amount,
+            execute_after,
+            interval_seconds,
+            kind,
+            max_executions,
+        );
 
-        if amount <= 0 {
-            panic_with_error!(env, Error::InvalidAmount);
-        }
-        if execute_at < env.ledger().sequence() {
-            panic_with_error!(env, Error::InvalidExecuteAt);
-        }
-        if kind == ScheduleKind::Recurring && interval_ledgers == 0 {
-            panic_with_error!(env, Error::InvalidInterval);
-        }
+        let reserved = checked_reserved(&env, amount, max_executions);
+        let contract = env.current_contract_address();
+        TokenClient::new(&env, &token).transfer(&payer, &contract, &reserved);
 
-        let id: u64 = env
+        let id = env
             .storage()
             .instance()
-            .get(&Key::Counter)
+            .get(&DataKey::Counter)
             .unwrap_or(0u64)
-            + 1;
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(env, Error::ArithmeticOverflow));
 
-        let s = Schedule {
-            payer: payer.clone(),
-            recipient: recipient.clone(),
+        let schedule = Schedule {
+            payer,
+            recipient,
             token,
             amount,
-            execute_at,
-            interval_ledgers,
+            execute_after,
+            interval_seconds,
             kind,
             status: ScheduleStatus::Pending,
             executions: 0,
+            max_executions,
         };
 
-        save_schedule(&env, id, &s);
-        env.storage().instance().set(&Key::Counter, &id);
-
-        env.events().publish(
-            (symbol_short!("sched"), symbol_short!("created")),
-            (id, payer, recipient, amount, execute_at),
-        );
-
+        save_schedule(&env, id, &schedule);
+        env.storage().instance().set(&DataKey::Counter, &id);
+        bump_instance(&env);
+        emit(&env, symbol_short!("created"), id);
         id
     }
 
-    // -----------------------------------------------------------------------
-    // Cancellation
-    // -----------------------------------------------------------------------
-
-    /// Cancel a pending schedule. Only the payer or admin may cancel.
-    pub fn cancel(env: Env, caller: Address, id: u64) {
-        require_not_paused(&env);
-        bump_instance(&env);
-
-        caller.require_auth();
-
-        let mut s = load_schedule(&env, id);
-
-        // Allow payer or admin.
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&Key::Admin)
-            .unwrap_or_else(|| panic_with_error!(env, Error::NotInitialized));
-        if caller != s.payer && caller != admin {
-            panic_with_error!(env, Error::Unauthorized);
-        }
-
-        if s.status != ScheduleStatus::Pending {
-            panic_with_error!(env, Error::NotPending);
-        }
-
-        s.status = ScheduleStatus::Cancelled;
-        save_schedule(&env, id, &s);
-
-        env.events().publish(
-            (symbol_short!("sched"), symbol_short!("cancelled")),
-            (id, caller),
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // Modification
-    // -----------------------------------------------------------------------
-
-    /// Modify a pending schedule's amount and/or interval. Only the payer may modify.
-    ///
-    /// Pass `0` for `new_amount` or `new_interval` to leave that field unchanged.
-    pub fn modify(env: Env, payer: Address, id: u64, new_amount: i128, new_interval: u32) {
-        require_not_paused(&env);
-        bump_instance(&env);
-
-        payer.require_auth();
-
-        let mut s = load_schedule(&env, id);
-
-        if s.payer != payer {
-            panic_with_error!(env, Error::Unauthorized);
-        }
-        if s.status != ScheduleStatus::Pending {
-            panic_with_error!(env, Error::NotPending);
-        }
-
-        if new_amount > 0 {
-            s.amount = new_amount;
-        }
-        if new_interval > 0 {
-            if s.kind == ScheduleKind::OneTime {
-                panic_with_error!(env, Error::InvalidInterval);
-            }
-            s.interval_ledgers = new_interval;
-        }
-
-        save_schedule(&env, id, &s);
-
-        env.events().publish(
-            (symbol_short!("sched"), symbol_short!("modified")),
-            (id, s.amount, s.interval_ledgers),
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // Execution (permissionless keeper)
-    // -----------------------------------------------------------------------
-
-    /// Execute a due schedule. Anyone may call this.
-    ///
-    /// For one-time schedules the status becomes `Executed` after success.
-    /// For recurring schedules the `execute_at` advances by `interval_ledgers`.
     pub fn execute(env: Env, id: u64) {
         require_not_paused(&env);
-        bump_instance(&env);
+        let mut schedule = load_schedule(&env, id);
 
-        let mut s = load_schedule(&env, id);
-
-        if s.status != ScheduleStatus::Pending {
+        if schedule.status != ScheduleStatus::Pending {
             panic_with_error!(env, Error::NotPending);
         }
-        if env.ledger().sequence() < s.execute_at {
+        if env.ledger().timestamp() < schedule.execute_after {
             panic_with_error!(env, Error::NotDue);
         }
 
-        // Transfer from payer to recipient.
-        TokenClient::new(&env, &s.token).transfer(&s.payer, &s.recipient, &s.amount);
+        let contract = env.current_contract_address();
+        TokenClient::new(&env, &schedule.token).transfer(
+            &contract,
+            &schedule.recipient,
+            &schedule.amount,
+        );
 
-        s.executions += 1;
+        schedule.executions = schedule
+            .executions
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(env, Error::ArithmeticOverflow));
 
-        match s.kind {
-            ScheduleKind::OneTime => {
-                s.status = ScheduleStatus::Executed;
-            }
-            ScheduleKind::Recurring => {
-                s.execute_at = env.ledger().sequence() + s.interval_ledgers;
-                // status stays Pending for next execution
-            }
+        if schedule.executions >= schedule.max_executions {
+            schedule.status = ScheduleStatus::Executed;
+        } else {
+            schedule.execute_after = env
+                .ledger()
+                .timestamp()
+                .checked_add(schedule.interval_seconds)
+                .unwrap_or_else(|| panic_with_error!(env, Error::ArithmeticOverflow));
         }
 
-        save_schedule(&env, id, &s);
-
-        env.events().publish(
-            (symbol_short!("sched"), symbol_short!("executed")),
-            (id, s.payer, s.recipient, s.amount, s.executions),
-        );
+        save_schedule(&env, id, &schedule);
+        bump_instance(&env);
+        emit(&env, symbol_short!("executed"), id);
     }
 
-    // -----------------------------------------------------------------------
-    // Admin: pause / unpause / upgrade / transfer_admin
-    // -----------------------------------------------------------------------
+    pub fn cancel(env: Env, caller: Address, id: u64) {
+        require_not_paused(&env);
+        caller.require_auth();
+
+        let mut schedule = load_schedule(&env, id);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(env, Error::NotInitialized));
+
+        if caller != schedule.payer && caller != admin {
+            panic_with_error!(env, Error::Unauthorized);
+        }
+        if schedule.status != ScheduleStatus::Pending {
+            panic_with_error!(env, Error::NotPending);
+        }
+
+        let refund = checked_reserved(&env, schedule.amount, remaining_executions(&schedule));
+        schedule.status = ScheduleStatus::Cancelled;
+        save_schedule(&env, id, &schedule);
+
+        if refund > 0 {
+            TokenClient::new(&env, &schedule.token).transfer(
+                &env.current_contract_address(),
+                &schedule.payer,
+                &refund,
+            );
+        }
+        bump_instance(&env);
+        emit(&env, symbol_short!("cancelled"), id);
+    }
+
+    pub fn modify(
+        env: Env,
+        payer: Address,
+        id: u64,
+        new_recipient: Option<Address>,
+        new_amount: i128,
+        new_execute_after: u64,
+        new_interval_seconds: u64,
+        new_max_executions: u32,
+    ) {
+        require_not_paused(&env);
+        payer.require_auth();
+
+        let mut schedule = load_schedule(&env, id);
+        if schedule.payer != payer {
+            panic_with_error!(env, Error::Unauthorized);
+        }
+        if schedule.status != ScheduleStatus::Pending {
+            panic_with_error!(env, Error::NotPending);
+        }
+
+        let old_reserved = checked_reserved(&env, schedule.amount, remaining_executions(&schedule));
+
+        if let Some(recipient) = new_recipient {
+            schedule.recipient = recipient;
+        }
+        if new_amount < 0 {
+            panic_with_error!(env, Error::InvalidAmount);
+        }
+        if new_amount > 0 {
+            schedule.amount = new_amount;
+        }
+        if new_execute_after > 0 {
+            if new_execute_after < env.ledger().timestamp() {
+                panic_with_error!(env, Error::InvalidExecuteAfter);
+            }
+            schedule.execute_after = new_execute_after;
+        }
+        if new_interval_seconds > 0 {
+            if schedule.kind == ScheduleKind::OneTime {
+                panic_with_error!(env, Error::InvalidInterval);
+            }
+            schedule.interval_seconds = new_interval_seconds;
+        }
+        if new_max_executions > 0 {
+            if schedule.kind == ScheduleKind::OneTime && new_max_executions != 1 {
+                panic_with_error!(env, Error::InvalidExecutionLimit);
+            }
+            if new_max_executions <= schedule.executions {
+                panic_with_error!(env, Error::InvalidExecutionLimit);
+            }
+            schedule.max_executions = new_max_executions;
+        }
+
+        validate_schedule(
+            &env,
+            schedule.amount,
+            schedule.execute_after,
+            schedule.interval_seconds,
+            schedule.kind,
+            schedule.max_executions,
+        );
+
+        let new_reserved = checked_reserved(&env, schedule.amount, remaining_executions(&schedule));
+        let token = TokenClient::new(&env, &schedule.token);
+        let contract = env.current_contract_address();
+        if new_reserved > old_reserved {
+            let top_up = new_reserved - old_reserved;
+            token.transfer(&payer, &contract, &top_up);
+        } else if old_reserved > new_reserved {
+            let refund = old_reserved - new_reserved;
+            token.transfer(&contract, &schedule.payer, &refund);
+        }
+
+        save_schedule(&env, id, &schedule);
+        bump_instance(&env);
+        emit(&env, symbol_short!("modified"), id);
+    }
 
     pub fn pause(env: Env) {
         require_admin(&env);
-        env.storage().instance().set(&Key::Paused, &true);
+        env.storage().instance().set(&DataKey::Paused, &true);
+        bump_instance(&env);
         env.events()
-            .publish((symbol_short!("sched"), symbol_short!("paused")), ());
+            .publish((symbol_short!("schedule"), symbol_short!("paused")), ());
     }
 
     pub fn unpause(env: Env) {
         require_admin(&env);
-        env.storage().instance().set(&Key::Paused, &false);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        bump_instance(&env);
         env.events()
-            .publish((symbol_short!("sched"), symbol_short!("unpaused")), ());
+            .publish((symbol_short!("schedule"), symbol_short!("unpaused")), ());
+    }
+
+    pub fn transfer_admin(env: Env, new_admin: Address) {
+        require_admin(&env);
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        bump_instance(&env);
+        env.events().publish(
+            (symbol_short!("schedule"), symbol_short!("adm_xfer")),
+            new_admin,
+        );
     }
 
     pub fn upgrade(env: Env, new_wasm_hash: soroban_sdk::BytesN<32>) {
         require_admin(&env);
         env.deployer().update_current_contract_wasm(new_wasm_hash);
     }
-
-    pub fn transfer_admin(env: Env, new_admin: Address) {
-        require_admin(&env);
-        env.storage().instance().set(&Key::Admin, &new_admin);
-        env.events().publish(
-            (symbol_short!("sched"), symbol_short!("adm_xfer")),
-            new_admin,
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // Views
-    // -----------------------------------------------------------------------
 
     pub fn get_schedule(env: Env, id: u64) -> Schedule {
         load_schedule(&env, id)
@@ -406,16 +432,19 @@ impl PaymentScheduler {
     pub fn get_admin(env: Env) -> Address {
         env.storage()
             .instance()
-            .get(&Key::Admin)
+            .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(env, Error::NotInitialized))
     }
 
     pub fn is_paused(env: Env) -> bool {
-        env.storage().instance().get(&Key::Paused).unwrap_or(false)
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
     }
 
     pub fn schedule_count(env: Env) -> u64 {
-        env.storage().instance().get(&Key::Counter).unwrap_or(0)
+        env.storage().instance().get(&DataKey::Counter).unwrap_or(0)
     }
 }
 

--- a/contracts/payment-scheduler/src/test.rs
+++ b/contracts/payment-scheduler/src/test.rs
@@ -11,18 +11,10 @@ fn sdk_err(e: Error) -> SdkError {
     SdkError::from_contract_error(e as u32)
 }
 
-fn create_token(env: &Env, admin: &Address) -> Address {
-    env.register_stellar_asset_contract_v2(admin.clone())
-        .address()
-}
-
-fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
-    StellarAssetClient::new(env, token).mint(to, &amount);
-}
-
 struct Setup {
     env: Env,
     client: PaymentSchedulerClient<'static>,
+    contract: Address,
     admin: Address,
     payer: Address,
     recipient: Address,
@@ -33,58 +25,65 @@ impl Setup {
     fn new() -> Self {
         let env = Env::default();
         env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
 
         let admin = Address::generate(&env);
         let payer = Address::generate(&env);
         let recipient = Address::generate(&env);
-        let token = create_token(&env, &admin);
-        mint(&env, &token, &payer, 1_000_000);
+        let token = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        StellarAssetClient::new(&env, &token).mint(&payer, &1_000_000);
 
-        let contract_id = env.register_contract(None, PaymentScheduler);
-        let client = PaymentSchedulerClient::new(&env, &contract_id);
+        let contract = env.register_contract(None, PaymentScheduler);
+        let client = PaymentSchedulerClient::new(&env, &contract);
         client.initialize(&admin);
+        let client: PaymentSchedulerClient<'static> = unsafe { core::mem::transmute(client) };
 
-        let client: PaymentSchedulerClient<'static> =
-            unsafe { core::mem::transmute(client) };
-
-        Setup { env, client, admin, payer, recipient, token }
+        Self {
+            env,
+            client,
+            contract,
+            admin,
+            payer,
+            recipient,
+            token,
+        }
     }
 
-    /// Schedule a one-time payment due at current ledger + `offset`.
-    fn schedule_one_time(&self, offset: u32) -> u64 {
-        let due = self.env.ledger().sequence() + offset;
+    fn one_time(&self, offset: u64, amount: i128) -> u64 {
         self.client.schedule(
             &self.payer,
             &self.recipient,
             &self.token,
-            &100i128,
-            &due,
-            &0u32,
+            &amount,
+            &(self.env.ledger().timestamp() + offset),
+            &0,
             &ScheduleKind::OneTime,
+            &1,
         )
     }
 
-    /// Schedule a recurring payment due at current ledger + `offset` with `interval`.
-    fn schedule_recurring(&self, offset: u32, interval: u32) -> u64 {
-        let due = self.env.ledger().sequence() + offset;
+    fn recurring(&self, offset: u64, interval: u64, amount: i128, max: u32) -> u64 {
         self.client.schedule(
             &self.payer,
             &self.recipient,
             &self.token,
-            &100i128,
-            &due,
+            &amount,
+            &(self.env.ledger().timestamp() + offset),
             &interval,
             &ScheduleKind::Recurring,
+            &max,
         )
+    }
+
+    fn token_client(&self) -> TokenClient<'_> {
+        TokenClient::new(&self.env, &self.token)
     }
 }
 
-// ---------------------------------------------------------------------------
-// Initialisation
-// ---------------------------------------------------------------------------
-
 #[test]
-fn test_double_init_rejected() {
+fn double_initialize_rejected() {
     let s = Setup::new();
     assert_eq!(
         s.client.try_initialize(&s.admin),
@@ -92,290 +91,248 @@ fn test_double_init_rejected() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Schedule creation
-// ---------------------------------------------------------------------------
-
 #[test]
-fn test_schedule_stores_correctly() {
+fn one_time_schedule_escrows_funds() {
     let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    let sched = s.client.get_schedule(&id);
-    assert_eq!(sched.payer, s.payer);
-    assert_eq!(sched.recipient, s.recipient);
-    assert_eq!(sched.amount, 100);
-    assert_eq!(sched.kind, ScheduleKind::OneTime);
-    assert_eq!(sched.status, ScheduleStatus::Pending);
-    assert_eq!(sched.executions, 0);
+    let id = s.one_time(60, 250);
+    let schedule = s.client.get_schedule(&id);
+
+    assert_eq!(schedule.payer, s.payer);
+    assert_eq!(schedule.recipient, s.recipient);
+    assert_eq!(schedule.amount, 250);
+    assert_eq!(schedule.execute_after, 1_060);
+    assert_eq!(schedule.kind, ScheduleKind::OneTime);
+    assert_eq!(schedule.status, ScheduleStatus::Pending);
+    assert_eq!(schedule.max_executions, 1);
+    assert_eq!(s.token_client().balance(&s.contract), 250);
 }
 
 #[test]
-fn test_schedule_invalid_amount_rejected() {
+fn recurring_schedule_escrows_all_occurrences() {
     let s = Setup::new();
-    let due = s.env.ledger().sequence() + 100;
+    let id = s.recurring(60, 30, 100, 4);
+    let schedule = s.client.get_schedule(&id);
+
+    assert_eq!(schedule.kind, ScheduleKind::Recurring);
+    assert_eq!(schedule.interval_seconds, 30);
+    assert_eq!(schedule.max_executions, 4);
+    assert_eq!(s.token_client().balance(&s.contract), 400);
+}
+
+#[test]
+fn schedule_validation_rejects_invalid_inputs() {
+    let s = Setup::new();
+
     assert_eq!(
         s.client.try_schedule(
-            &s.payer, &s.recipient, &s.token,
-            &0i128, &due, &0u32, &ScheduleKind::OneTime
+            &s.payer,
+            &s.recipient,
+            &s.token,
+            &0,
+            &1_100,
+            &0,
+            &ScheduleKind::OneTime,
+            &1,
         ),
         Err(Ok(sdk_err(Error::InvalidAmount)))
     );
-}
 
-#[test]
-fn test_schedule_past_execute_at_rejected() {
-    let s = Setup::new();
-    s.env.ledger().with_mut(|l| l.sequence_number = 100);
     assert_eq!(
         s.client.try_schedule(
-            &s.payer, &s.recipient, &s.token,
-            &100i128, &50u32, &0u32, &ScheduleKind::OneTime
+            &s.payer,
+            &s.recipient,
+            &s.token,
+            &100,
+            &999,
+            &0,
+            &ScheduleKind::OneTime,
+            &1,
         ),
-        Err(Ok(sdk_err(Error::InvalidExecuteAt)))
+        Err(Ok(sdk_err(Error::InvalidExecuteAfter)))
     );
-}
 
-#[test]
-fn test_recurring_zero_interval_rejected() {
-    let s = Setup::new();
-    let due = s.env.ledger().sequence() + 100;
     assert_eq!(
         s.client.try_schedule(
-            &s.payer, &s.recipient, &s.token,
-            &100i128, &due, &0u32, &ScheduleKind::Recurring
+            &s.payer,
+            &s.recipient,
+            &s.token,
+            &100,
+            &1_100,
+            &0,
+            &ScheduleKind::Recurring,
+            &2,
         ),
         Err(Ok(sdk_err(Error::InvalidInterval)))
     );
-}
 
-#[test]
-fn test_schedule_counter_increments() {
-    let s = Setup::new();
-    assert_eq!(s.client.schedule_count(), 0);
-    s.schedule_one_time(100);
-    assert_eq!(s.client.schedule_count(), 1);
-    s.schedule_one_time(200);
-    assert_eq!(s.client.schedule_count(), 2);
-}
-
-// ---------------------------------------------------------------------------
-// Execution
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_execute_before_due_rejected() {
-    let s = Setup::new();
-    let id = s.schedule_one_time(100);
     assert_eq!(
-        s.client.try_execute(&id),
-        Err(Ok(sdk_err(Error::NotDue)))
+        s.client.try_schedule(
+            &s.payer,
+            &s.recipient,
+            &s.token,
+            &100,
+            &1_100,
+            &0,
+            &ScheduleKind::OneTime,
+            &2,
+        ),
+        Err(Ok(sdk_err(Error::InvalidExecutionLimit)))
     );
 }
 
 #[test]
-fn test_execute_one_time_transfers_and_marks_executed() {
+fn execute_one_time_pays_recipient_and_completes() {
     let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    s.env.ledger().with_mut(|l| l.sequence_number += 100);
+    let id = s.one_time(60, 250);
 
+    s.env.ledger().set_timestamp(1_060);
     s.client.execute(&id);
 
-    assert_eq!(TokenClient::new(&s.env, &s.token).balance(&s.recipient), 100);
-    let sched = s.client.get_schedule(&id);
-    assert_eq!(sched.status, ScheduleStatus::Executed);
-    assert_eq!(sched.executions, 1);
+    let schedule = s.client.get_schedule(&id);
+    assert_eq!(schedule.status, ScheduleStatus::Executed);
+    assert_eq!(schedule.executions, 1);
+    assert_eq!(s.token_client().balance(&s.recipient), 250);
+    assert_eq!(s.token_client().balance(&s.contract), 0);
 }
 
 #[test]
-fn test_execute_one_time_twice_rejected() {
+fn execute_before_due_rejected() {
     let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    s.env.ledger().with_mut(|l| l.sequence_number += 100);
-    s.client.execute(&id);
-    assert_eq!(
-        s.client.try_execute(&id),
-        Err(Ok(sdk_err(Error::NotPending)))
-    );
+    let id = s.one_time(60, 100);
+
+    assert_eq!(s.client.try_execute(&id), Err(Ok(sdk_err(Error::NotDue))));
 }
 
 #[test]
-fn test_execute_recurring_advances_execute_at() {
+fn recurring_execution_advances_until_limit() {
     let s = Setup::new();
-    let id = s.schedule_recurring(100, 500);
-    s.env.ledger().with_mut(|l| l.sequence_number += 100);
+    let id = s.recurring(10, 30, 100, 3);
 
-    s.client.execute(&id);
-
-    let sched = s.client.get_schedule(&id);
-    assert_eq!(sched.status, ScheduleStatus::Pending);
-    assert_eq!(sched.executions, 1);
-    // next due = current ledger + interval
-    let current = s.env.ledger().sequence();
-    assert_eq!(sched.execute_at, current + 500);
-}
-
-#[test]
-fn test_execute_recurring_multiple_times() {
-    let s = Setup::new();
-    let id = s.schedule_recurring(100, 500);
-
-    for i in 1u32..=3 {
-        s.env.ledger().with_mut(|l| l.sequence_number += 500);
+    for expected in 1..=3 {
+        s.env
+            .ledger()
+            .set_timestamp(s.env.ledger().timestamp() + 30);
         s.client.execute(&id);
-        assert_eq!(s.client.get_schedule(&id).executions, i);
+        assert_eq!(s.client.get_schedule(&id).executions, expected);
     }
 
-    assert_eq!(
-        TokenClient::new(&s.env, &s.token).balance(&s.recipient),
-        300
-    );
+    let schedule = s.client.get_schedule(&id);
+    assert_eq!(schedule.status, ScheduleStatus::Executed);
+    assert_eq!(s.token_client().balance(&s.recipient), 300);
+    assert_eq!(s.token_client().balance(&s.contract), 0);
 }
 
-// ---------------------------------------------------------------------------
-// Cancellation
-// ---------------------------------------------------------------------------
-
 #[test]
-fn test_cancel_by_payer() {
+fn cancel_by_payer_refunds_remaining_escrow() {
     let s = Setup::new();
-    let id = s.schedule_one_time(100);
+    let id = s.recurring(10, 30, 100, 3);
+
+    s.env.ledger().set_timestamp(1_010);
+    s.client.execute(&id);
     s.client.cancel(&s.payer, &id);
-    assert_eq!(s.client.get_schedule(&id).status, ScheduleStatus::Cancelled);
+
+    let schedule = s.client.get_schedule(&id);
+    assert_eq!(schedule.status, ScheduleStatus::Cancelled);
+    assert_eq!(s.token_client().balance(&s.recipient), 100);
+    assert_eq!(s.token_client().balance(&s.contract), 0);
+    assert_eq!(s.token_client().balance(&s.payer), 999_900);
 }
 
 #[test]
-fn test_cancel_by_admin() {
+fn cancel_by_admin_allowed_but_other_caller_rejected() {
     let s = Setup::new();
-    let id = s.schedule_one_time(100);
+    let id = s.one_time(60, 100);
+    let other = Address::generate(&s.env);
+
+    assert_eq!(
+        s.client.try_cancel(&other, &id),
+        Err(Ok(sdk_err(Error::Unauthorized)))
+    );
+
     s.client.cancel(&s.admin, &id);
     assert_eq!(s.client.get_schedule(&id).status, ScheduleStatus::Cancelled);
 }
 
 #[test]
-fn test_cancel_by_unauthorized_rejected() {
+fn modify_amount_tops_up_and_refunds() {
     let s = Setup::new();
-    let id = s.schedule_one_time(100);
+    let id = s.recurring(60, 30, 100, 3);
+
+    s.client.modify(&s.payer, &id, &None, &150, &0, &0, &0);
+    assert_eq!(s.client.get_schedule(&id).amount, 150);
+    assert_eq!(s.token_client().balance(&s.contract), 450);
+
+    s.client.modify(&s.payer, &id, &None, &50, &0, &0, &0);
+    assert_eq!(s.client.get_schedule(&id).amount, 50);
+    assert_eq!(s.token_client().balance(&s.contract), 150);
+}
+
+#[test]
+fn modify_recipient_time_interval_and_limit() {
+    let s = Setup::new();
+    let id = s.recurring(60, 30, 100, 3);
+    let new_recipient = Address::generate(&s.env);
+
+    s.client.modify(
+        &s.payer,
+        &id,
+        &Some(new_recipient.clone()),
+        &0,
+        &1_200,
+        &45,
+        &2,
+    );
+
+    let schedule = s.client.get_schedule(&id);
+    assert_eq!(schedule.recipient, new_recipient);
+    assert_eq!(schedule.execute_after, 1_200);
+    assert_eq!(schedule.interval_seconds, 45);
+    assert_eq!(schedule.max_executions, 2);
+    assert_eq!(s.token_client().balance(&s.contract), 200);
+}
+
+#[test]
+fn unauthorized_or_completed_modify_rejected() {
+    let s = Setup::new();
+    let id = s.one_time(10, 100);
     let other = Address::generate(&s.env);
+
     assert_eq!(
-        s.client.try_cancel(&other, &id),
+        s.client.try_modify(&other, &id, &None, &200, &0, &0, &0),
         Err(Ok(sdk_err(Error::Unauthorized)))
     );
-}
 
-#[test]
-fn test_cancel_already_cancelled_rejected() {
-    let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    s.client.cancel(&s.payer, &id);
-    assert_eq!(
-        s.client.try_cancel(&s.payer, &id),
-        Err(Ok(sdk_err(Error::NotPending)))
-    );
-}
-
-#[test]
-fn test_execute_cancelled_schedule_rejected() {
-    let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    s.client.cancel(&s.payer, &id);
-    s.env.ledger().with_mut(|l| l.sequence_number += 100);
-    assert_eq!(
-        s.client.try_execute(&id),
-        Err(Ok(sdk_err(Error::NotPending)))
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Modification
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_modify_amount() {
-    let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    s.client.modify(&s.payer, &id, &200i128, &0u32);
-    assert_eq!(s.client.get_schedule(&id).amount, 200);
-}
-
-#[test]
-fn test_modify_interval_recurring() {
-    let s = Setup::new();
-    let id = s.schedule_recurring(100, 500);
-    s.client.modify(&s.payer, &id, &0i128, &1000u32);
-    assert_eq!(s.client.get_schedule(&id).interval_ledgers, 1000);
-}
-
-#[test]
-fn test_modify_interval_on_one_time_rejected() {
-    let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    assert_eq!(
-        s.client.try_modify(&s.payer, &id, &0i128, &500u32),
-        Err(Ok(sdk_err(Error::InvalidInterval)))
-    );
-}
-
-#[test]
-fn test_modify_by_unauthorized_rejected() {
-    let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    let other = Address::generate(&s.env);
-    assert_eq!(
-        s.client.try_modify(&other, &id, &200i128, &0u32),
-        Err(Ok(sdk_err(Error::Unauthorized)))
-    );
-}
-
-#[test]
-fn test_modify_executed_schedule_rejected() {
-    let s = Setup::new();
-    let id = s.schedule_one_time(100);
-    s.env.ledger().with_mut(|l| l.sequence_number += 100);
+    s.env.ledger().set_timestamp(1_010);
     s.client.execute(&id);
     assert_eq!(
-        s.client.try_modify(&s.payer, &id, &200i128, &0u32),
+        s.client.try_modify(&s.payer, &id, &None, &200, &0, &0, &0),
         Err(Ok(sdk_err(Error::NotPending)))
     );
 }
 
-// ---------------------------------------------------------------------------
-// Pause / unpause
-// ---------------------------------------------------------------------------
-
 #[test]
-fn test_pause_blocks_schedule_and_execute() {
+fn pause_blocks_mutating_user_flows() {
     let s = Setup::new();
-    let id = s.schedule_one_time(100);
+    let id = s.one_time(10, 100);
 
     s.client.pause();
     assert!(s.client.is_paused());
 
-    let due = s.env.ledger().sequence() + 100;
-    assert_eq!(
-        s.client.try_schedule(
-            &s.payer, &s.recipient, &s.token,
-            &100i128, &due, &0u32, &ScheduleKind::OneTime
-        ),
-        Err(Ok(sdk_err(Error::ContractPaused)))
-    );
-
-    s.env.ledger().with_mut(|l| l.sequence_number += 100);
     assert_eq!(
         s.client.try_execute(&id),
+        Err(Ok(sdk_err(Error::ContractPaused)))
+    );
+    assert_eq!(
+        s.client.try_cancel(&s.payer, &id),
         Err(Ok(sdk_err(Error::ContractPaused)))
     );
 
     s.client.unpause();
     assert!(!s.client.is_paused());
-    s.client.execute(&id); // should succeed now
 }
 
-// ---------------------------------------------------------------------------
-// Admin transfer
-// ---------------------------------------------------------------------------
-
 #[test]
-fn test_transfer_admin() {
+fn transfer_admin_updates_admin() {
     let s = Setup::new();
     let new_admin = Address::generate(&s.env);
     s.client.transfer_admin(&new_admin);

--- a/contracts/price-oracle/src/lib.rs
+++ b/contracts/price-oracle/src/lib.rs
@@ -1,25 +1,72 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Env, Symbol,
-    Vec,
+    contract, contractclient, contracterror, contractimpl, contracttype, panic_with_error, vec,
+    Address, Env, Symbol, Vec,
 };
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const KEY_ADMIN: Symbol = symbol_short!("admin");
-const KEY_SOURCES: Symbol = symbol_short!("sources");
-/// Default max age for a price entry before it is considered stale (in ledgers, ~5 s each).
-/// 720 ledgers ≈ 1 hour.
-const DEFAULT_MAX_AGE: u32 = 720;
-const INSTANCE_TTL_EXTEND: u32 = 6_307_200;
+const MAX_SOURCES: u32 = 20;
+const DEFAULT_MIN_SOURCES: u32 = 1;
 const INSTANCE_TTL_THRESHOLD: u32 = 100_000;
+const INSTANCE_TTL_EXTEND: u32 = 6_307_200;
+const PERSISTENT_TTL_THRESHOLD: u32 = 50_000;
+const PERSISTENT_TTL_EXTEND: u32 = 3_153_600;
 
-// ---------------------------------------------------------------------------
-// Errors
-// ---------------------------------------------------------------------------
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    Admin,
+    Base,
+    Assets,
+    Decimals,
+    Resolution,
+    FallbackMaxAge,
+    Sources,
+    Source(Address),
+    Asset(Asset),
+    Manual(Address, Asset),
+    LastGood(Asset),
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Asset {
+    Stellar(Address),
+    Other(Symbol),
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PriceData {
+    pub price: i128,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum SourceType {
+    Manual = 1,
+    Sep40 = 2,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct SourceConfig {
+    pub source_type: SourceType,
+    pub enabled: bool,
+    pub max_age_seconds: u64,
+    pub max_deviation_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct AggregatedPrice {
+    pub price: i128,
+    pub timestamp: u64,
+    pub sources_used: u32,
+    pub decimals: u32,
+    pub is_fallback: bool,
+}
 
 #[contracterror]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -33,283 +80,487 @@ pub enum OracleError {
     StalePrice = 7,
     InvalidPrice = 8,
     TooManySources = 9,
+    InvalidDecimals = 10,
+    InvalidDeviation = 11,
+    InvalidMinSources = 12,
+    ArithmeticOverflow = 13,
 }
 
-// ---------------------------------------------------------------------------
-// Data types
-// ---------------------------------------------------------------------------
-
-/// A single price submission from one oracle source.
-#[contracttype]
-#[derive(Clone)]
-pub struct PriceEntry {
-    /// Price scaled by 1_000_000 (6 decimal places).
-    pub price: i128,
-    /// Ledger sequence at which this price was recorded.
-    pub timestamp: u32,
-    /// Source address that submitted this price.
-    pub source: Address,
+#[contractclient(name = "ExternalPriceFeedClient")]
+pub trait ExternalPriceFeed {
+    fn decimals(env: Env) -> u32;
+    fn lastprice(env: Env, asset: Asset) -> Option<PriceData>;
 }
 
-/// Aggregated price result returned to callers.
-#[contracttype]
-#[derive(Clone)]
-pub struct AggregatedPrice {
-    pub price: i128,
-    pub sources_used: u32,
-    pub timestamp: u32,
-}
-
-// ---------------------------------------------------------------------------
-// Storage helpers
-// ---------------------------------------------------------------------------
-
-fn storage_key_price(asset: &Symbol) -> (Symbol, Symbol) {
-    (symbol_short!("price"), asset.clone())
-}
-
-fn require_admin(env: &Env) {
-    let admin: Address = env.storage().instance().get(&KEY_ADMIN).unwrap();
-    admin.require_auth();
-}
-
-fn is_initialized(env: &Env) -> bool {
-    env.storage().instance().has(&KEY_ADMIN)
-}
-
-fn bump(env: &Env) {
+fn bump_instance(env: &Env) {
     env.storage()
         .instance()
         .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND);
 }
 
-// ---------------------------------------------------------------------------
-// Contract
-// ---------------------------------------------------------------------------
+fn bump_persistent(env: &Env, key: &DataKey) {
+    env.storage()
+        .persistent()
+        .extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
+}
+
+fn require_initialized(env: &Env) {
+    if !env.storage().instance().has(&DataKey::Admin) {
+        panic_with_error!(env, OracleError::NotInitialized);
+    }
+}
+
+fn require_admin(env: &Env) -> Address {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(env, OracleError::NotInitialized));
+    admin.require_auth();
+    admin
+}
+
+fn sources(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Sources)
+        .unwrap_or(vec![env])
+}
+
+fn source_config(env: &Env, source: &Address) -> SourceConfig {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Source(source.clone()))
+        .unwrap_or_else(|| panic_with_error!(env, OracleError::SourceNotFound))
+}
+
+fn maybe_source_config(env: &Env, source: &Address) -> Option<SourceConfig> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Source(source.clone()))
+}
+
+fn target_decimals(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::Decimals)
+        .unwrap_or_else(|| panic_with_error!(env, OracleError::NotInitialized))
+}
+
+fn fallback_max_age(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::FallbackMaxAge)
+        .unwrap_or(0)
+}
+
+fn pow10(env: &Env, decimals: u32) -> i128 {
+    if decimals > 18 {
+        panic_with_error!(env, OracleError::InvalidDecimals);
+    }
+    let mut value = 1i128;
+    for _ in 0..decimals {
+        value = value
+            .checked_mul(10)
+            .unwrap_or_else(|| panic_with_error!(env, OracleError::ArithmeticOverflow));
+    }
+    value
+}
+
+fn normalize_price(env: &Env, price: i128, source_decimals: u32, target_decimals: u32) -> i128 {
+    if price <= 0 {
+        panic_with_error!(env, OracleError::InvalidPrice);
+    }
+    if source_decimals == target_decimals {
+        return price;
+    }
+    if source_decimals > 18 || target_decimals > 18 {
+        panic_with_error!(env, OracleError::InvalidDecimals);
+    }
+    if source_decimals < target_decimals {
+        price
+            .checked_mul(pow10(env, target_decimals - source_decimals))
+            .unwrap_or_else(|| panic_with_error!(env, OracleError::ArithmeticOverflow))
+    } else {
+        price / pow10(env, source_decimals - target_decimals)
+    }
+}
+
+fn abs_diff(a: i128, b: i128) -> i128 {
+    if a >= b {
+        a - b
+    } else {
+        b - a
+    }
+}
+
+fn within_deviation(price: i128, median: i128, max_deviation_bps: u32) -> bool {
+    if max_deviation_bps == 0 {
+        return true;
+    }
+    abs_diff(price, median) * 10_000 <= median * max_deviation_bps as i128
+}
+
+fn median(env: &Env, values: &Vec<i128>) -> i128 {
+    let n = values.len() as usize;
+    if n == 0 || n > MAX_SOURCES as usize {
+        panic_with_error!(env, OracleError::NoValidPrice);
+    }
+    let mut sorted = [0i128; MAX_SOURCES as usize];
+    for (i, value) in values.iter().enumerate() {
+        sorted[i] = value;
+    }
+    for i in 1..n {
+        let value = sorted[i];
+        let mut j = i;
+        while j > 0 && sorted[j - 1] > value {
+            sorted[j] = sorted[j - 1];
+            j -= 1;
+        }
+        sorted[j] = value;
+    }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    }
+}
+
+fn latest_timestamp(values: &Vec<PriceData>) -> u64 {
+    let mut latest = 0u64;
+    for value in values.iter() {
+        if value.timestamp > latest {
+            latest = value.timestamp;
+        }
+    }
+    latest
+}
+
+fn store_last_good(env: &Env, asset: &Asset, price: &AggregatedPrice) {
+    let key = DataKey::LastGood(asset.clone());
+    env.storage().persistent().set(&key, price);
+    bump_persistent(env, &key);
+}
+
+fn load_last_good(env: &Env, asset: &Asset) -> Option<AggregatedPrice> {
+    let key = DataKey::LastGood(asset.clone());
+    let price = env.storage().persistent().get(&key);
+    if price.is_some() {
+        bump_persistent(env, &key);
+    }
+    price
+}
+
+fn fallback_or_fail(env: &Env, asset: &Asset, now: u64) -> AggregatedPrice {
+    if let Some(mut fallback) = load_last_good(env, asset) {
+        if fallback_max_age(env) > 0
+            && now.saturating_sub(fallback.timestamp) <= fallback_max_age(env)
+        {
+            fallback.is_fallback = true;
+            return fallback;
+        }
+        panic_with_error!(env, OracleError::StalePrice);
+    }
+    panic_with_error!(env, OracleError::NoValidPrice);
+}
 
 #[contract]
 pub struct PriceOracle;
 
 #[contractimpl]
 impl PriceOracle {
-    /// Initialize the oracle with an admin and an optional list of trusted sources.
-    pub fn initialize(env: Env, admin: Address, sources: Vec<Address>) {
-        if is_initialized(&env) {
-            panic_with_error!(&env, OracleError::AlreadyInitialized);
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        base: Asset,
+        decimals: u32,
+        resolution: u32,
+        fallback_max_age_seconds: u64,
+    ) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(env, OracleError::AlreadyInitialized);
+        }
+        if decimals > 18 {
+            panic_with_error!(env, OracleError::InvalidDecimals);
         }
         admin.require_auth();
-        env.storage().instance().set(&KEY_ADMIN, &admin);
-        env.storage().instance().set(&KEY_SOURCES, &sources);
-        bump(&env);
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Base, &base);
+        let empty_assets: Vec<Asset> = vec![&env];
+        let empty_sources: Vec<Address> = vec![&env];
+        env.storage()
+            .instance()
+            .set(&DataKey::Assets, &empty_assets);
+        env.storage().instance().set(&DataKey::Decimals, &decimals);
+        env.storage()
+            .instance()
+            .set(&DataKey::Resolution, &resolution);
+        env.storage()
+            .instance()
+            .set(&DataKey::FallbackMaxAge, &fallback_max_age_seconds);
+        env.storage()
+            .instance()
+            .set(&DataKey::Sources, &empty_sources);
+        bump_instance(&env);
     }
 
-    // ------------------------------------------------------------------
-    // Admin: source management
-    // ------------------------------------------------------------------
-
-    /// Add a trusted oracle source.
-    pub fn add_source(env: Env, source: Address) {
-        if !is_initialized(&env) {
-            panic_with_error!(&env, OracleError::NotInitialized);
-        }
+    pub fn add_asset(env: Env, asset: Asset) {
         require_admin(&env);
-        let mut sources: Vec<Address> = env
+        let mut assets: Vec<Asset> = env
             .storage()
             .instance()
-            .get(&KEY_SOURCES)
+            .get(&DataKey::Assets)
             .unwrap_or(vec![&env]);
-        if sources.len() >= 10 {
-            panic_with_error!(&env, OracleError::TooManySources);
-        }
-        for s in sources.iter() {
-            if s == source {
-                panic_with_error!(&env, OracleError::SourceAlreadyExists);
+        for existing in assets.iter() {
+            if existing == asset {
+                bump_instance(&env);
+                return;
             }
         }
-        sources.push_back(source);
-        env.storage().instance().set(&KEY_SOURCES, &sources);
-        bump(&env);
+        assets.push_back(asset.clone());
+        env.storage().instance().set(&DataKey::Assets, &assets);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Asset(asset.clone()), &true);
+        bump_persistent(&env, &DataKey::Asset(asset));
+        bump_instance(&env);
     }
 
-    /// Remove a trusted oracle source.
-    pub fn remove_source(env: Env, source: Address) {
-        if !is_initialized(&env) {
-            panic_with_error!(&env, OracleError::NotInitialized);
-        }
+    pub fn add_source(
+        env: Env,
+        source: Address,
+        source_type: SourceType,
+        max_age_seconds: u64,
+        max_deviation_bps: u32,
+    ) {
         require_admin(&env);
-        let sources: Vec<Address> = env
+        if max_deviation_bps > 10_000 {
+            panic_with_error!(env, OracleError::InvalidDeviation);
+        }
+        let mut all_sources = sources(&env);
+        if all_sources.len() >= MAX_SOURCES {
+            panic_with_error!(env, OracleError::TooManySources);
+        }
+        if env
             .storage()
+            .persistent()
+            .has(&DataKey::Source(source.clone()))
+        {
+            panic_with_error!(env, OracleError::SourceAlreadyExists);
+        }
+        let config = SourceConfig {
+            source_type,
+            enabled: true,
+            max_age_seconds,
+            max_deviation_bps,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Source(source.clone()), &config);
+        bump_persistent(&env, &DataKey::Source(source.clone()));
+        all_sources.push_back(source);
+        env.storage()
             .instance()
-            .get(&KEY_SOURCES)
-            .unwrap_or(vec![&env]);
-        let mut new_sources: Vec<Address> = vec![&env];
+            .set(&DataKey::Sources, &all_sources);
+        bump_instance(&env);
+    }
+
+    pub fn remove_source(env: Env, source: Address) {
+        require_admin(&env);
+        let all_sources = sources(&env);
+        let mut updated = vec![&env];
         let mut found = false;
-        for s in sources.iter() {
-            if s == source {
+        for existing in all_sources.iter() {
+            if existing == source {
                 found = true;
             } else {
-                new_sources.push_back(s);
+                updated.push_back(existing);
             }
         }
         if !found {
-            panic_with_error!(&env, OracleError::SourceNotFound);
+            panic_with_error!(env, OracleError::SourceNotFound);
         }
-        env.storage().instance().set(&KEY_SOURCES, &new_sources);
-        bump(&env);
+        env.storage().persistent().remove(&DataKey::Source(source));
+        env.storage().instance().set(&DataKey::Sources, &updated);
+        bump_instance(&env);
     }
 
-    // ------------------------------------------------------------------
-    // Price submission
-    // ------------------------------------------------------------------
-
-    /// Submit a price for an asset. Caller must be a registered source.
-    pub fn submit_price(env: Env, source: Address, asset: Symbol, price: i128) {
-        if !is_initialized(&env) {
-            panic_with_error!(&env, OracleError::NotInitialized);
-        }
-        source.require_auth();
-        if price <= 0 {
-            panic_with_error!(&env, OracleError::InvalidPrice);
-        }
-        // Verify source is trusted
-        let sources: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&KEY_SOURCES)
-            .unwrap_or(vec![&env]);
-        let mut trusted = false;
-        for s in sources.iter() {
-            if s == source {
-                trusted = true;
-                break;
-            }
-        }
-        if !trusted {
-            panic_with_error!(&env, OracleError::Unauthorized);
-        }
-
-        let entry = PriceEntry {
-            price,
-            timestamp: env.ledger().sequence(),
-            source: source.clone(),
-        };
-        let key = storage_key_price(&asset);
-        // Store per-source price using persistent storage
-        let source_key = (key.clone(), source);
-        env.storage().persistent().set(&source_key, &entry);
+    pub fn set_source_enabled(env: Env, source: Address, enabled: bool) {
+        require_admin(&env);
+        let mut config = source_config(&env, &source);
+        config.enabled = enabled;
         env.storage()
             .persistent()
-            .extend_ttl(&source_key, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND);
-        bump(&env);
+            .set(&DataKey::Source(source.clone()), &config);
+        bump_persistent(&env, &DataKey::Source(source));
+        bump_instance(&env);
     }
 
-    // ------------------------------------------------------------------
-    // Price retrieval
-    // ------------------------------------------------------------------
-
-    /// Get the median-aggregated price for an asset.
-    /// Returns an error if no valid (non-stale) prices exist.
-    pub fn get_price(env: Env, asset: Symbol) -> AggregatedPrice {
-        Self::get_price_with_max_age(env, asset, DEFAULT_MAX_AGE)
-    }
-
-    /// Get price with a custom staleness threshold (in ledgers).
-    pub fn get_price_with_max_age(env: Env, asset: Symbol, max_age: u32) -> AggregatedPrice {
-        if !is_initialized(&env) {
-            panic_with_error!(&env, OracleError::NotInitialized);
+    pub fn submit_price(env: Env, source: Address, asset: Asset, price: i128) {
+        require_initialized(&env);
+        source.require_auth();
+        if price <= 0 {
+            panic_with_error!(env, OracleError::InvalidPrice);
         }
-        let sources: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&KEY_SOURCES)
-            .unwrap_or(vec![&env]);
-        let current_ledger = env.ledger().sequence();
-        let key = storage_key_price(&asset);
+        let config = maybe_source_config(&env, &source)
+            .unwrap_or_else(|| panic_with_error!(env, OracleError::Unauthorized));
+        if !config.enabled || config.source_type != SourceType::Manual {
+            panic_with_error!(env, OracleError::Unauthorized);
+        }
+        let data = PriceData {
+            price: normalize_price(&env, price, target_decimals(&env), target_decimals(&env)),
+            timestamp: env.ledger().timestamp(),
+        };
+        let key = DataKey::Manual(source, asset);
+        env.storage().persistent().set(&key, &data);
+        bump_persistent(&env, &key);
+    }
 
-        let mut prices: Vec<i128> = vec![&env];
-        let mut latest_ts: u32 = 0;
+    pub fn get_price(env: Env, asset: Asset) -> AggregatedPrice {
+        Self::get_price_with_min_sources(env, asset, DEFAULT_MIN_SOURCES)
+    }
 
-        for source in sources.iter() {
-            let source_key = (key.clone(), source);
-            if let Some(entry) = env
-                .storage()
-                .persistent()
-                .get::<_, PriceEntry>(&source_key)
-            {
-                let age = current_ledger.saturating_sub(entry.timestamp);
-                if age <= max_age {
-                    prices.push_back(entry.price);
-                    if entry.timestamp > latest_ts {
-                        latest_ts = entry.timestamp;
+    pub fn get_price_with_min_sources(env: Env, asset: Asset, min_sources: u32) -> AggregatedPrice {
+        require_initialized(&env);
+        if min_sources == 0 || min_sources > MAX_SOURCES {
+            panic_with_error!(env, OracleError::InvalidMinSources);
+        }
+
+        let target = target_decimals(&env);
+        let now = env.ledger().timestamp();
+        let all_sources = sources(&env);
+        let mut prices = vec![&env];
+        let mut raw = vec![&env];
+        let mut configs = vec![&env];
+
+        for source in all_sources.iter() {
+            let config = source_config(&env, &source);
+            if !config.enabled {
+                continue;
+            }
+
+            let maybe_price = match config.source_type {
+                SourceType::Manual => env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, PriceData>(&DataKey::Manual(source.clone(), asset.clone())),
+                SourceType::Sep40 => {
+                    let client = ExternalPriceFeedClient::new(&env, &source);
+                    match client.lastprice(&asset) {
+                        Some(data) => {
+                            let decimals = client.decimals();
+                            Some(PriceData {
+                                price: normalize_price(&env, data.price, decimals, target),
+                                timestamp: data.timestamp,
+                            })
+                        }
+                        None => None,
                     }
+                }
+            };
+
+            if let Some(data) = maybe_price {
+                if data.price <= 0 {
+                    continue;
+                }
+                if now.saturating_sub(data.timestamp) <= config.max_age_seconds {
+                    prices.push_back(data.price);
+                    raw.push_back(data);
+                    configs.push_back(config);
                 }
             }
         }
 
-        if prices.is_empty() {
-            panic_with_error!(&env, OracleError::NoValidPrice);
+        if prices.len() < min_sources {
+            return fallback_or_fail(&env, &asset, now);
         }
 
-        let median = Self::median(&env, &prices);
-        bump(&env);
+        let first_median = median(&env, &prices);
+        let mut filtered = vec![&env];
+        let mut filtered_data = vec![&env];
+        for i in 0..prices.len() {
+            let price = prices.get(i).unwrap();
+            let config = configs.get(i).unwrap();
+            if within_deviation(price, first_median, config.max_deviation_bps) {
+                filtered.push_back(price);
+                filtered_data.push_back(raw.get(i).unwrap());
+            }
+        }
 
-        AggregatedPrice {
-            price: median,
-            sources_used: prices.len(),
-            timestamp: latest_ts,
+        if filtered.len() < min_sources {
+            return fallback_or_fail(&env, &asset, now);
+        }
+
+        let result = AggregatedPrice {
+            price: median(&env, &filtered),
+            timestamp: latest_timestamp(&filtered_data),
+            sources_used: filtered.len(),
+            decimals: target,
+            is_fallback: false,
+        };
+        store_last_good(&env, &asset, &result);
+        bump_instance(&env);
+        result
+    }
+
+    pub fn get_source_price(env: Env, source: Address, asset: Asset) -> PriceData {
+        require_initialized(&env);
+        let config = source_config(&env, &source);
+        match config.source_type {
+            SourceType::Manual => env
+                .storage()
+                .persistent()
+                .get(&DataKey::Manual(source, asset))
+                .unwrap_or_else(|| panic_with_error!(env, OracleError::NoValidPrice)),
+            SourceType::Sep40 => ExternalPriceFeedClient::new(&env, &source)
+                .lastprice(&asset)
+                .unwrap_or_else(|| panic_with_error!(env, OracleError::NoValidPrice)),
         }
     }
 
-    /// Returns the latest raw price from a specific source (no staleness check).
-    pub fn get_source_price(env: Env, source: Address, asset: Symbol) -> PriceEntry {
-        if !is_initialized(&env) {
-            panic_with_error!(&env, OracleError::NotInitialized);
-        }
-        let key = storage_key_price(&asset);
-        let source_key = (key, source);
-        env.storage()
-            .persistent()
-            .get(&source_key)
-            .unwrap_or_else(|| panic_with_error!(&env, OracleError::NoValidPrice))
-    }
-
-    /// List all registered sources.
     pub fn get_sources(env: Env) -> Vec<Address> {
-        if !is_initialized(&env) {
-            panic_with_error!(&env, OracleError::NotInitialized);
-        }
+        require_initialized(&env);
+        sources(&env)
+    }
+
+    pub fn get_source_config(env: Env, source: Address) -> SourceConfig {
+        require_initialized(&env);
+        source_config(&env, &source)
+    }
+
+    pub fn base(env: Env) -> Asset {
         env.storage()
             .instance()
-            .get(&KEY_SOURCES)
+            .get(&DataKey::Base)
+            .unwrap_or_else(|| panic_with_error!(env, OracleError::NotInitialized))
+    }
+
+    pub fn assets(env: Env) -> Vec<Asset> {
+        require_initialized(&env);
+        env.storage()
+            .instance()
+            .get(&DataKey::Assets)
             .unwrap_or(vec![&env])
     }
 
-    // ------------------------------------------------------------------
-    // Internal helpers
-    // ------------------------------------------------------------------
+    pub fn decimals(env: Env) -> u32 {
+        target_decimals(&env)
+    }
 
-    /// Compute median of a non-empty Vec<i128> using insertion sort.
-    fn median(env: &Env, values: &Vec<i128>) -> i128 {
-        let n = values.len() as usize;
-        // Copy into a fixed-size array (max 10 sources)
-        let mut arr = [0i128; 10];
-        for (i, v) in values.iter().enumerate() {
-            arr[i] = v;
-        }
-        // Insertion sort
-        for i in 1..n {
-            let key = arr[i];
-            let mut j = i;
-            while j > 0 && arr[j - 1] > key {
-                arr[j] = arr[j - 1];
-                j -= 1;
-            }
-            arr[j] = key;
-        }
-        if n % 2 == 1 {
-            arr[n / 2]
-        } else {
-            (arr[n / 2 - 1] + arr[n / 2]) / 2
-        }
+    pub fn resolution(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Resolution)
+            .unwrap_or_else(|| panic_with_error!(env, OracleError::NotInitialized))
+    }
+
+    pub fn lastprice(env: Env, asset: Asset) -> Option<PriceData> {
+        let result = Self::get_price(env, asset);
+        Some(PriceData {
+            price: result.price,
+            timestamp: result.timestamp,
+        })
     }
 }
+
+mod test;

--- a/contracts/price-oracle/src/test.rs
+++ b/contracts/price-oracle/src/test.rs
@@ -1,121 +1,238 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, Env, Error as SdkError,
+};
 
-fn setup() -> (Env, PriceOracleClient<'static>, Address, Address, Address) {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register_contract(None, PriceOracle);
-    let client = PriceOracleClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
-    let source1 = Address::generate(&env);
-    let source2 = Address::generate(&env);
-    client.initialize(&admin, &vec![&env, source1.clone(), source2.clone()]);
-    (env, client, admin, source1, source2)
+fn sdk_err(e: OracleError) -> SdkError {
+    SdkError::from_contract_error(e as u32)
+}
+
+#[contract]
+struct MockSep40;
+
+#[contracttype]
+enum MockKey {
+    Decimals,
+    Price(Asset),
+}
+
+#[contractimpl]
+impl MockSep40 {
+    pub fn set_decimals(env: Env, decimals: u32) {
+        env.storage().instance().set(&MockKey::Decimals, &decimals);
+    }
+
+    pub fn set_price(env: Env, asset: Asset, price: i128, timestamp: u64) {
+        env.storage()
+            .persistent()
+            .set(&MockKey::Price(asset), &PriceData { price, timestamp });
+    }
+
+    pub fn decimals(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&MockKey::Decimals)
+            .unwrap_or(7)
+    }
+
+    pub fn lastprice(env: Env, asset: Asset) -> Option<PriceData> {
+        env.storage().persistent().get(&MockKey::Price(asset))
+    }
+}
+
+struct Setup {
+    env: Env,
+    client: PriceOracleClient<'static>,
+    admin: Address,
+    manual1: Address,
+    manual2: Address,
+    asset: Asset,
+}
+
+impl Setup {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+
+        let admin = Address::generate(&env);
+        let manual1 = Address::generate(&env);
+        let manual2 = Address::generate(&env);
+        let contract = env.register_contract(None, PriceOracle);
+        let client = PriceOracleClient::new(&env, &contract);
+        let base = Asset::Other(symbol_short!("USD"));
+        client.initialize(&admin, &base, &7, &60, &600);
+
+        let client: PriceOracleClient<'static> = unsafe { core::mem::transmute(client) };
+        let asset = Asset::Other(symbol_short!("XLM"));
+
+        Self {
+            env,
+            client,
+            admin,
+            manual1,
+            manual2,
+            asset,
+        }
+    }
+
+    fn add_manual_sources(&self) {
+        self.client
+            .add_source(&self.manual1, &SourceType::Manual, &300, &1_000);
+        self.client
+            .add_source(&self.manual2, &SourceType::Manual, &300, &1_000);
+    }
 }
 
 #[test]
-fn test_initialize() {
-    let (_, client, _, source1, source2) = setup();
-    let sources = client.get_sources();
-    assert_eq!(sources.len(), 2);
-    assert!(sources.contains(&source1));
-    assert!(sources.contains(&source2));
+fn initialize_sets_sep40_metadata() {
+    let s = Setup::new();
+    assert_eq!(s.client.decimals(), 7);
+    assert_eq!(s.client.resolution(), 60);
+    assert_eq!(s.client.base(), Asset::Other(symbol_short!("USD")));
+    assert_eq!(s.client.get_sources().len(), 0);
 }
 
 #[test]
-#[should_panic(expected = "AlreadyInitialized")]
-fn test_double_initialize() {
-    let (env, client, admin, _, _) = setup();
-    client.initialize(&admin, &vec![&env]);
+fn double_initialize_rejected() {
+    let s = Setup::new();
+    assert_eq!(
+        s.client
+            .try_initialize(&s.admin, &Asset::Other(symbol_short!("USD")), &7, &60, &600),
+        Err(Ok(sdk_err(OracleError::AlreadyInitialized)))
+    );
 }
 
 #[test]
-fn test_submit_and_get_price() {
-    let (_, client, _, source1, source2) = setup();
-    let asset = symbol_short!("XLM");
-    client.submit_price(&source1, &asset, &1_100_000); // 1.10
-    client.submit_price(&source2, &asset, &1_200_000); // 1.20
-    let result = client.get_price(&asset);
-    // median of [1_100_000, 1_200_000] = 1_150_000
-    assert_eq!(result.price, 1_150_000);
+fn manual_sources_are_median_aggregated() {
+    let s = Setup::new();
+    s.add_manual_sources();
+
+    s.client.submit_price(&s.manual1, &s.asset, &1_100_0000);
+    s.client.submit_price(&s.manual2, &s.asset, &1_300_0000);
+
+    let result = s.client.get_price(&s.asset);
+    assert_eq!(result.price, 1_200_0000);
+    assert_eq!(result.sources_used, 2);
+    assert_eq!(result.decimals, 7);
+    assert!(!result.is_fallback);
+}
+
+#[test]
+fn stale_manual_price_is_excluded() {
+    let s = Setup::new();
+    s.add_manual_sources();
+
+    s.client.submit_price(&s.manual1, &s.asset, &1_000_0000);
+    s.env.ledger().set_timestamp(1_400);
+    s.client.submit_price(&s.manual2, &s.asset, &2_000_0000);
+
+    let result = s.client.get_price_with_min_sources(&s.asset, &1);
+    assert_eq!(result.price, 2_000_0000);
+    assert_eq!(result.sources_used, 1);
+}
+
+#[test]
+fn untrusted_manual_submit_rejected() {
+    let s = Setup::new();
+    let rogue = Address::generate(&s.env);
+    assert_eq!(
+        s.client.try_submit_price(&rogue, &s.asset, &1_000_0000),
+        Err(Ok(sdk_err(OracleError::Unauthorized)))
+    );
+}
+
+#[test]
+fn invalid_manual_price_rejected() {
+    let s = Setup::new();
+    s.add_manual_sources();
+    assert_eq!(
+        s.client.try_submit_price(&s.manual1, &s.asset, &0),
+        Err(Ok(sdk_err(OracleError::InvalidPrice)))
+    );
+}
+
+#[test]
+fn sep40_source_is_read_and_normalized() {
+    let s = Setup::new();
+    let mock_id = s.env.register_contract(None, MockSep40);
+    let mock = MockSep40Client::new(&s.env, &mock_id);
+    mock.set_decimals(&6);
+    mock.set_price(&s.asset, &1_250_000, &1_000);
+
+    s.client
+        .add_source(&mock_id, &SourceType::Sep40, &300, &1_000);
+    let result = s.client.get_price(&s.asset);
+
+    assert_eq!(result.price, 1_250_0000);
+    assert_eq!(result.sources_used, 1);
+}
+
+#[test]
+fn outlier_is_removed_by_deviation_filter() {
+    let s = Setup::new();
+    s.add_manual_sources();
+    let manual3 = Address::generate(&s.env);
+    s.client
+        .add_source(&manual3, &SourceType::Manual, &300, &500);
+
+    s.client.submit_price(&s.manual1, &s.asset, &1_000_0000);
+    s.client.submit_price(&s.manual2, &s.asset, &1_020_0000);
+    s.client.submit_price(&manual3, &s.asset, &2_000_0000);
+
+    let result = s.client.get_price_with_min_sources(&s.asset, &2);
+    assert_eq!(result.price, 1_010_0000);
     assert_eq!(result.sources_used, 2);
 }
 
 #[test]
-fn test_single_source_price() {
-    let (_, client, _, source1, _) = setup();
-    let asset = symbol_short!("USDC");
-    client.submit_price(&source1, &asset, &1_000_000);
-    let result = client.get_price(&asset);
-    assert_eq!(result.price, 1_000_000);
-    assert_eq!(result.sources_used, 1);
+fn last_good_price_used_as_fallback() {
+    let s = Setup::new();
+    s.add_manual_sources();
+
+    s.client.submit_price(&s.manual1, &s.asset, &1_000_0000);
+    let fresh = s.client.get_price(&s.asset);
+    assert!(!fresh.is_fallback);
+
+    s.env.ledger().set_timestamp(1_350);
+    let fallback = s.client.get_price(&s.asset);
+    assert_eq!(fallback.price, 1_000_0000);
+    assert!(fallback.is_fallback);
 }
 
 #[test]
-#[should_panic(expected = "NoValidPrice")]
-fn test_no_price_submitted() {
-    let (_, client, _, _, _) = setup();
-    client.get_price(&symbol_short!("BTC"));
+fn stale_last_good_fallback_rejected() {
+    let s = Setup::new();
+    s.add_manual_sources();
+
+    s.client.submit_price(&s.manual1, &s.asset, &1_000_0000);
+    s.client.get_price(&s.asset);
+
+    s.env.ledger().set_timestamp(2_000);
+    assert_eq!(
+        s.client.try_get_price(&s.asset),
+        Err(Ok(sdk_err(OracleError::StalePrice)))
+    );
 }
 
 #[test]
-#[should_panic(expected = "InvalidPrice")]
-fn test_invalid_price_zero() {
-    let (_, client, _, source1, _) = setup();
-    client.submit_price(&source1, &symbol_short!("XLM"), &0);
-}
+fn source_management_updates_config() {
+    let s = Setup::new();
+    s.client
+        .add_source(&s.manual1, &SourceType::Manual, &300, &1_000);
+    assert_eq!(s.client.get_sources().len(), 1);
 
-#[test]
-#[should_panic(expected = "Unauthorized")]
-fn test_untrusted_source_rejected() {
-    let (env, client, _, _, _) = setup();
-    let rogue = Address::generate(&env);
-    client.submit_price(&rogue, &symbol_short!("XLM"), &1_000_000);
-}
+    let config = s.client.get_source_config(&s.manual1);
+    assert_eq!(config.source_type, SourceType::Manual);
+    assert!(config.enabled);
 
-#[test]
-fn test_add_remove_source() {
-    let (env, client, _, source1, source2) = setup();
-    let source3 = Address::generate(&env);
-    client.add_source(&source3);
-    assert_eq!(client.get_sources().len(), 3);
-    client.remove_source(&source2);
-    assert_eq!(client.get_sources().len(), 2);
-    assert!(!client.get_sources().contains(&source2));
-}
+    s.client.set_source_enabled(&s.manual1, &false);
+    assert!(!s.client.get_source_config(&s.manual1).enabled);
 
-#[test]
-#[should_panic(expected = "SourceNotFound")]
-fn test_remove_nonexistent_source() {
-    let (env, client, _, _, _) = setup();
-    let unknown = Address::generate(&env);
-    client.remove_source(&unknown);
-}
-
-#[test]
-fn test_stale_price_excluded() {
-    let (env, client, _, source1, source2) = setup();
-    let asset = symbol_short!("XLM");
-    // source1 submits at ledger 0 (default)
-    client.submit_price(&source1, &asset, &1_000_000);
-    // Advance ledger past DEFAULT_MAX_AGE (720)
-    env.ledger().set_sequence_number(800);
-    // source2 submits fresh price
-    client.submit_price(&source2, &asset, &2_000_000);
-    // Only source2's price should be used (max_age=720, source1 is 800 ledgers old)
-    let result = client.get_price_with_max_age(&asset, &720);
-    assert_eq!(result.sources_used, 1);
-    assert_eq!(result.price, 2_000_000);
-}
-
-#[test]
-fn test_get_source_price() {
-    let (_, client, _, source1, _) = setup();
-    let asset = symbol_short!("XLM");
-    client.submit_price(&source1, &asset, &1_500_000);
-    let entry = client.get_source_price(&source1, &asset);
-    assert_eq!(entry.price, 1_500_000);
-    assert_eq!(entry.source, source1);
+    s.client.remove_source(&s.manual1);
+    assert_eq!(s.client.get_sources().len(), 0);
 }


### PR DESCRIPTION
Closes #160 
Closes #177 

# PR Description

Fixes #160 by implementing an escrow-backed payment scheduler for one-time and recurring payments. Payers fund schedules up front, anyone can execute due schedules, and pending schedules can be cancelled or modified with proper authorization and escrow reconciliation.

Fixes #177 by implementing a Soroban price oracle aggregator for payment routing. The oracle supports trusted manual sources and external SEP-40-style oracle contracts, aggregates valid prices with median filtering, rejects stale/outlier data, and falls back to the last good aggregate when live sources are unavailable.

# Changed

- #160 Added escrow-backed one-time and recurring payment schedules.
- #160 Added cancellation, modification, pause/admin controls, validation, checked arithmetic, TTL handling, and focused tests.
- #177 Added manual and SEP-40-style oracle source support.
- #177 Added price normalization, median aggregation, staleness checks, deviation filtering, last-good fallback, source management, and focused tests.
- Added the correctly cased `contracts/payment-history/Cargo.toml` required for the contracts workspace to load during tests.