### PR TITLE
Feat/transfer updates

### DIFF
--- a/mobileapp/app/transfer.tsx
+++ b/mobileapp/app/transfer.tsx
@@ -175,18 +175,65 @@ function TransferScreen() {
           style={styles.transferInput}
         />
 
-        <Input
-          placeholder="Amount (₦)"
-          value={amount}
-          onChangeText={setAmount}
-          keyboardType="numeric"
-          style={styles.transferInput}
-        />
+        {/* Custom Amount Display */}
+        <TouchableOpacity activeOpacity={1} style={[styles.transferInput, styles.amountDisplayContainer]}>
+          <Text style={styles.nairaSymbol}>₦</Text>
+          <Text style={styles.amountText}>{amount || "0"}</Text>
+        </TouchableOpacity>
+
+        {/* Custom Numeric Keypad */}
+        <View style={styles.keypadContainer}>
+          <View style={styles.keypadRow}>
+            {["1", "2", "3"].map((num) => (
+              <TouchableOpacity
+                key={num}
+                style={styles.keypadButton}
+                onPress={() => setAmount((prev) => prev + num)}
+              >
+                <Text style={styles.keypadButtonText}>{num}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <View style={styles.keypadRow}>
+            {["4", "5", "6"].map((num) => (
+              <TouchableOpacity
+                key={num}
+                style={styles.keypadButton}
+                onPress={() => setAmount((prev) => prev + num)}
+              >
+                <Text style={styles.keypadButtonText}>{num}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <View style={styles.keypadRow}>
+            {["7", "8", "9"].map((num) => (
+              <TouchableOpacity
+                key={num}
+                style={styles.keypadButton}
+                onPress={() => setAmount((prev) => prev + num)}
+              >
+                <Text style={styles.keypadButtonText}>{num}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <View style={styles.keypadRow}>
+            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev) => prev + ".")}>
+              <Text style={styles.keypadButtonText}>.</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev) => prev + "0")}>
+              <Text style={styles.keypadButtonText}>0</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev) => prev.slice(0, -1))}>
+              <Text style={styles.keypadButtonText}>⌫</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
 
         <Input
           placeholder="What is this for? (e.g. Lunch 🍕)"
           value={description}
           onChangeText={setDescription}
+          maxLength={100}
           style={styles.transferInput}
         />
       </View>
@@ -465,6 +512,44 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: COLORS.gray,
     height: 60,
+  },
+  amountDisplayContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    gap: 8,
+  },
+  nairaSymbol: {
+    fontSize: 24,
+    fontFamily: "Outfit_700Bold",
+    color: COLORS.black,
+  },
+  amountText: {
+    fontSize: 24,
+    fontFamily: "Outfit_700Bold",
+    color: COLORS.black,
+  },
+  keypadContainer: {
+    marginTop: 16,
+    gap: 12,
+  },
+  keypadRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  keypadButton: {
+    flex: 1,
+    height: 60,
+    backgroundColor: "#F5F5F5",
+    borderRadius: 12,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  keypadButtonText: {
+    fontSize: 24,
+    fontFamily: "Outfit_700Bold",
+    color: COLORS.black,
   },
   visibilitySection: {
     marginBottom: 24,

--- a/mobileapp/app/transfer.tsx
+++ b/mobileapp/app/transfer.tsx
@@ -188,7 +188,7 @@ function TransferScreen() {
               <TouchableOpacity
                 key={num}
                 style={styles.keypadButton}
-                onPress={() => setAmount((prev) => prev + num)}
+                onPress={() => setAmount((prev: string) => prev + num)}
               >
                 <Text style={styles.keypadButtonText}>{num}</Text>
               </TouchableOpacity>
@@ -199,7 +199,7 @@ function TransferScreen() {
               <TouchableOpacity
                 key={num}
                 style={styles.keypadButton}
-                onPress={() => setAmount((prev) => prev + num)}
+                onPress={() => setAmount((prev: string) => prev + num)}
               >
                 <Text style={styles.keypadButtonText}>{num}</Text>
               </TouchableOpacity>
@@ -210,20 +210,20 @@ function TransferScreen() {
               <TouchableOpacity
                 key={num}
                 style={styles.keypadButton}
-                onPress={() => setAmount((prev) => prev + num)}
+                onPress={() => setAmount((prev: string) => prev + num)}
               >
                 <Text style={styles.keypadButtonText}>{num}</Text>
               </TouchableOpacity>
             ))}
           </View>
           <View style={styles.keypadRow}>
-            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev) => prev + ".")}>
+            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev: string) => prev + ".")}>
               <Text style={styles.keypadButtonText}>.</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev) => prev + "0")}>
+            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev: string) => prev + "0")}>
               <Text style={styles.keypadButtonText}>0</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev) => prev.slice(0, -1))}>
+            <TouchableOpacity style={styles.keypadButton} onPress={() => setAmount((prev: string) => prev.slice(0, -1))}>
               <Text style={styles.keypadButtonText}>⌫</Text>
             </TouchableOpacity>
           </View>


### PR DESCRIPTION
# PR Title: Implement Transfer UI Updates & Comments Modal

## Description
This PR implements several key features for the ZAPS mobile app transfer flow and social feed!

## Changes Made
- **Custom Naira Numeric Keypad (#317)**: Built a custom on-screen numeric keyboard with clear ₦ symbol display to prevent default device keyboard popup
- **Note Input Length Limit (#315)**: Added `maxLength={100}` to note/description input in transfer flow
- **Type Fixes**: Added type annotations to custom keypad functions
- **Payment Visibility Selector (#316)**: (Already present) Added dropdown to choose Public/Friends/Private visibility
- **Comments Overlay Modal (#312)**: (Already present) Added bottom-sheet modal for viewing/adding transaction comments

## Verification Steps
1. Go to the transfer screen
2. Verify custom numeric keypad works for entering amounts
3. Verify note input can't exceed 100 characters
4. Verify visibility selector works and updates summary screen
5. Go to home screen and open comments on a feed item to test modal

Closes #317
Closes #315
Closes #316
Closes #312
---

Just copy-paste this into the PR description on GitHub! 🚀