### PR TITLE
feat: implement username registration mapping address to zaps id (SC-…

### DIFF
--- a/contracts/contracts/user_registry/src/lib.rs
+++ b/contracts/contracts/user_registry/src/lib.rs
@@ -1,28 +1,64 @@
 #![no_std]
 #![allow(dead_code, unused_variables, unused_imports, unexpected_cfgs)]
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Map};
 
 #[contract]
 pub struct UserRegistryContract;
+
+// Storage keys for persistent storage
+const ADDRESS_TO_USERNAME: &str = "address_to_username";
+const USERNAME_TO_ADDRESS: &str = "username_to_address";
 
 #[contractimpl]
 impl UserRegistryContract {
     /// Register a username mapping to the sender's address
     pub fn register_user(env: Env, user: Address, username: String) {
-        // TODO: Implement SC-001 (Register address to username mapping)
         // TODO: Implement SC-002 (Validate username rules: length 3-15, alphanumeric, lowercase)
         user.require_auth();
-        panic!("unimplemented: register_user");
+
+        // Convert storage keys to Soroban String
+        let address_key = String::from_str(&env, ADDRESS_TO_USERNAME);
+        let username_key = String::from_str(&env, USERNAME_TO_ADDRESS);
+
+        // Get storage instances
+        let address_to_username: Map<Address, String> = env.storage().persistent().get(&address_key).unwrap_or(Map::new(&env));
+        let username_to_address: Map<String, Address> = env.storage().persistent().get(&username_key).unwrap_or(Map::new(&env));
+
+        // Check if username is already taken (uniqueness validation)
+        if username_to_address.contains_key(username.clone()) {
+            panic!("username already taken");
+        }
+
+        // Store the mappings
+        let mut address_to_username = address_to_username;
+        let mut username_to_address = username_to_address;
+        
+        address_to_username.set(user.clone(), username.clone());
+        username_to_address.set(username, user);
+
+        // Persist to storage
+        env.storage().persistent().set(&address_key, &address_to_username);
+        env.storage().persistent().set(&username_key, &username_to_address);
     }
 
     /// Retrieve the Address associated with a username
     pub fn get_address(env: Env, username: String) -> Address {
-        panic!("unimplemented: get_address");
+        let username_key = String::from_str(&env, USERNAME_TO_ADDRESS);
+        let username_to_address: Map<String, Address> = env.storage().persistent().get(&username_key)
+            .unwrap_or(Map::new(&env));
+        
+        username_to_address.get(username)
+            .unwrap_or_else(|| panic!("username not found"))
     }
 
     /// Retrieve the username associated with an Address
     pub fn get_username(env: Env, user: Address) -> String {
-        panic!("unimplemented: get_username");
+        let address_key = String::from_str(&env, ADDRESS_TO_USERNAME);
+        let address_to_username: Map<Address, String> = env.storage().persistent().get(&address_key)
+            .unwrap_or(Map::new(&env));
+        
+        address_to_username.get(user)
+            .unwrap_or_else(|| panic!("address not registered"))
     }
 
     /// Update user profile metadata (e.g. avatar URI)


### PR DESCRIPTION
#closes #274 
# Implement Username Registration mapping Address -> Zaps ID (SC-001)

## Summary
Implements the core registration function to allow users to register a unique Zaps username (e.g. `ebube.zaps`) with bidirectional address-to-username mapping using Soroban persistent storage.

## Changes
- **File Modified:** [contracts/contracts/user_registry/src/lib.rs](cci:7://file:///c:/Users/HomePC/Documents/D/zaps/contracts/contracts/user_registry/src/lib.rs:0:0-0:0)
- Added storage keys for persistent bidirectional mappings
- Implemented [register_user()](cci:1://file:///c:/Users/HomePC/Documents/D/zaps/contracts/contracts/user_registry/src/lib.rs:13:4-41:5) with:
  - Address-to-username mapping
  - Username-to-address mapping for reverse lookup
  - Uniqueness validation to prevent duplicate usernames
  - Authentication requirement via `user.require_auth()`
- Implemented [get_address()](cci:1://file:///c:/Users/HomePC/Documents/D/zaps/contracts/contracts/user_registry/src/lib.rs:43:4-51:5) to retrieve address by username
- Implemented [get_username()](cci:1://file:///c:/Users/HomePC/Documents/D/zaps/contracts/contracts/user_registry/src/lib.rs:48:4-55:5) to retrieve username by address
- Fixed Soroban SDK type compatibility by converting storage keys to `String` type

## Acceptance Criteria
- ✅ Address to String map is correctly written and retrieved
- ✅ Registrations are unique (duplicate usernames rejected)

## Testing
```bash
# Build
cargo build --target wasm32-unknown-unknown --release

# Test
cargo test
#closes 