### PR TITLE
feat(mobileapp): add prominent Pay / Request action button on persona…

### DIFF
--- a/mobileapp/app/(personal)/home.tsx
+++ b/mobileapp/app/(personal)/home.tsx
@@ -266,21 +266,20 @@ export default function HomeScreen() {
           <Text style={styles.balanceLabel}>Stellar Wallet Balance</Text>
           <Text style={styles.balanceAmount}>{balance}</Text>
 
-          {/* Quick Actions Redesign */}
-          <View style={styles.quickActions}>
-            <TouchableOpacity
-              style={[styles.actionBtn, styles.payBtn]}
-              onPress={() => router.push("/transfer")}
-            >
-              <Ionicons
-                name="send"
-                size={18}
-                color={COLORS.secondary}
-                style={{ marginRight: 6 }}
-              />
-              <Text style={styles.payBtnText}>Pay / Request</Text>
-            </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.payRequestButton}
+            onPress={() => router.push("/transfer")}
+          >
+            <Ionicons
+              name="send"
+              size={18}
+              color={COLORS.secondary}
+              style={styles.payRequestIcon}
+            />
+            <Text style={styles.payRequestButtonText}>Pay / Request</Text>
+          </TouchableOpacity>
 
+          <View style={styles.quickActions}>
             <TouchableOpacity
               style={[styles.actionBtn, styles.receiveBtn]}
               onPress={() => router.push("/receive")}
@@ -535,6 +534,29 @@ const styles = StyleSheet.create({
   quickActions: {
     flexDirection: "row",
     gap: 10,
+  },
+  payRequestButton: {
+    backgroundColor: COLORS.primary,
+    borderRadius: 18,
+    paddingVertical: 14,
+    paddingHorizontal: 18,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 14,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    elevation: 4,
+  },
+  payRequestButtonText: {
+    color: COLORS.secondary,
+    fontSize: 16,
+    fontFamily: "Outfit_700Bold",
+  },
+  payRequestIcon: {
+    marginRight: 8,
   },
   actionBtn: {
     flex: 1,


### PR DESCRIPTION
Description
This PR addresses Issue #313 ([FE-005]) by adding a highly accessible "Pay / Request" trigger button directly linked with the balance card interface inside the home screen matrix (mobileapp/app/(personal)/home.tsx). This update aims to remove user friction when initializing social peer-to-peer asset transfers.

🛠️ Changes Implemented
UI Action Hook: Integrated a TouchableOpacity action element inside the balance card view hierarchy in home.tsx.

Themed Styling: Styled the interactive trigger button leveraging the system's primary background brand colors, clear typographic text values, and standard padding properties.

Navigation Attachment: Configured the onPress callback hook to trigger and open the core transfer flow module or view sequence smoothly.

🧪 Quality Assurance & Testing
[x] Layout Accuracy: Verified that the touchable component layout scales appropriately across different device screens without breaking existing component flex layouts.

[x] Interaction Verification: Confirmed that clicking the action trigger fires the target transfer workflow seamlessly.

🔗 Dependencies
Closes #313