### PR TITLE
docs: add OpenAPI v3 spec for backend routes

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -31,6 +31,15 @@ components:
       description: JWT obtained from POST /api/auth/verify
 
   schemas:
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: Human-readable error message
+
     ChallengeResponse:
       type: object
       required:
@@ -57,7 +66,7 @@ components:
           type: string
           description: Challenge string previously obtained from GET /api/auth/challenge
 
-    VerifyResponse:
+    AuthResponse:
       type: object
       required:
         - token
@@ -65,13 +74,16 @@ components:
       properties:
         token:
           type: string
-          description: JWT valid for 24 hours; include as Authorization: Bearer header
+          description: "JWT valid for 24 hours; include as Authorization: Bearer header"
         username:
           type: string
           description: Auto-generated username prefixed with u_ followed by chars 2-15 of the Stellar address
 
     ProfileResponse:
       type: object
+      required:
+        - address
+        - username
       properties:
         address:
           type: string
@@ -105,14 +117,12 @@ components:
       properties:
         q:
           type: string
-          description: Search term matched against username and address (ILIKE)
+          description: Search term matched against username and address via ILIKE
         limit:
           type: integer
-          description: Max results to return
           default: 20
         offset:
           type: integer
-          description: Result offset for pagination
           default: 0
 
     SearchUser:
@@ -153,6 +163,7 @@ components:
       properties:
         status:
           type: string
+          description: Status of the friendship request or action result
           enum:
             - PENDING
             - ACCEPTED
@@ -189,7 +200,7 @@ components:
           nullable: true
         amount:
           type: string
-          description: Payment amount as a fixed-precision string
+          description: Payment amount as a fixed-precision string (micro-units / 100)
         currency:
           type: string
           description: Payment currency code (NGN or USDC)
@@ -202,7 +213,7 @@ components:
           type: integer
         has_liked:
           type: boolean
-          description: Whether the requesting user has liked this payment (always false for anonymous requests)
+          description: Whether the requesting user has liked this payment (false for anonymous requests)
         created_at:
           type: string
           format: date-time
@@ -226,10 +237,13 @@ components:
       properties:
         success:
           type: boolean
+          description: true if the like was recorded or unliked successfully
         likes_count:
           type: integer
+          description: Total number of likes on the payment after the action
         has_liked:
           type: boolean
+          description: true if the requesting user currently likes the payment
 
     CommentRequest:
       type: object
@@ -283,11 +297,7 @@ components:
       properties:
         source_chain:
           type: string
-          enum:
-            - STLR
-            - ETH
-            - BSC
-          description: Origin chain code
+          description: Origin chain code (e.g. STLR, ETH, BSC)
         source_token:
           type: string
           description: Source token contract address
@@ -296,10 +306,6 @@ components:
           description: Positive integer string representing token amount
         destination_chain:
           type: string
-          enum:
-            - STLR
-            - ETH
-            - BSC
           description: Target chain code
         destination_token:
           type: string
@@ -336,15 +342,11 @@ components:
         source_chain:
           type: string
           description: Source chain; defaults to STLR if omitted
-          enum:
-            - STLR
+          default: STLR
         destination_chain:
           type: string
           description: Target chain, or null if unknown
           nullable: true
-          enum:
-            - ETH
-            - BSC
         destination_address:
           type: string
           description: Receiver address on the destination chain
@@ -366,6 +368,7 @@ components:
           description: UUID of the bridge transaction record
         source_tx_hash:
           type: string
+          description: Source chain transaction hash
         status:
           type: string
           enum:
@@ -384,17 +387,16 @@ components:
       properties:
         source_tx_hash:
           type: string
+          description: Source chain transaction hash
         source_chain:
           type: string
+          description: Origin chain code
           enum:
             - STLR
         destination_chain:
           type: string
           nullable: true
           description: Destination chain; null if not yet determined
-          enum:
-            - ETH
-            - BSC
         status:
           type: string
           enum:
@@ -407,6 +409,7 @@ components:
         updated_at:
           type: string
           format: date-time
+          description: ISO8601 timestamp of last status update
 
 paths:
   /health:
@@ -458,27 +461,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VerifyResponse'
+                $ref: '#/components/schemas/AuthResponse'
         '400':
           description: Invalid signature format
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: Invalid signature format (must be hex or base64)
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Invalid signature format (must be hex or base64)
         '401':
           description: Signature verification failed
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: Signature verification failed
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Signature verification failed
         '500':
           description: Internal server error
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Internal database error
 
   /api/users/profile:
     get:
@@ -498,9 +505,19 @@ paths:
         '401':
           description: Missing or invalid JWT
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Missing authorization header
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Internal database error
 
     post:
       tags:
@@ -525,9 +542,15 @@ paths:
         '401':
           description: Missing or invalid JWT
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/users/search:
     get:
@@ -541,23 +564,9 @@ paths:
         - name: q
           in: query
           required: true
-          description: Search term matched against username and address
+          description: Search term matched against username and address (ILIKE)
           schema:
             type: string
-        - name: limit
-          in: query
-          required: false
-          description: Maximum number of results
-          schema:
-            type: integer
-            default: 20
-        - name: offset
-          in: query
-          required: false
-          description: Result offset for pagination
-          schema:
-            type: integer
-            default: 0
       responses:
         '200':
           description: Matching users
@@ -569,6 +578,16 @@ paths:
                   $ref: '#/components/schemas/SearchUser'
         '401':
           description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/users/friends:
     get:
@@ -589,7 +608,18 @@ paths:
                   $ref: '#/components/schemas/FriendUser'
         '401':
           description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
+  /api/users/friends/request:
     post:
       tags:
         - Users
@@ -612,31 +642,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/StatusResponse'
         '400':
-          description: Cannot friend yourself
+          description: Cannot friend yourself or invalid request
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Target user not found
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: Friendship already exists
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/users/friends/{id}/accept:
     post:
       tags:
         - Users
-      summary: Accept a pending friend request
+      summary: Accept an incoming friend request
       operationId: acceptFriendRequest
       security:
         - BearerAuth: []
@@ -644,7 +678,7 @@ paths:
         - name: id
           in: path
           required: true
-          description: UUID of the friendship record
+          description: UUID of the friendship record to accept
           schema:
             type: string
       responses:
@@ -654,20 +688,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusResponse'
-        '404':
-          description: No pending request found for this friendship ID
+        '400':
+          description: Invalid UUID format for friendship id
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Pending friend request not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/users/friends/{id}/reject:
     post:
       tags:
         - Users
-      summary: Reject a pending friend request
+      summary: Reject an incoming friend request
       operationId: rejectFriendRequest
       security:
         - BearerAuth: []
@@ -675,7 +719,7 @@ paths:
         - name: id
           in: path
           required: true
-          description: UUID of the friendship record
+          description: UUID of the friendship record to reject
           schema:
             type: string
       responses:
@@ -685,14 +729,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusResponse'
-        '404':
-          description: No pending request found for this friendship ID
+        '400':
+          description: Invalid UUID format for friendship id
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Pending friend request not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/feed/public:
     get:
@@ -713,7 +767,7 @@ paths:
         - name: offset
           in: query
           required: false
-          description: Result offset for pagination
+          description: Number of items to skip
           schema:
             type: integer
             default: 0
@@ -727,7 +781,17 @@ paths:
                 items:
                   $ref: '#/components/schemas/FeedItem'
         '401':
-          description: Missing or invalid JWT
+          description: Invalid or missing JWT when auth header is provided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/feed/friends:
     get:
@@ -748,7 +812,7 @@ paths:
         - name: offset
           in: query
           required: false
-          description: Result offset for pagination
+          description: Number of items to skip
           schema:
             type: integer
             default: 0
@@ -763,6 +827,16 @@ paths:
                   $ref: '#/components/schemas/FeedItem'
         '401':
           description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/feed/private:
     get:
@@ -783,7 +857,7 @@ paths:
         - name: offset
           in: query
           required: false
-          description: Result offset for pagination
+          description: Number of items to skip
           schema:
             type: integer
             default: 0
@@ -798,6 +872,16 @@ paths:
                   $ref: '#/components/schemas/FeedItem'
         '401':
           description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/social/like:
     post:
@@ -823,11 +907,15 @@ paths:
         '400':
           description: Invalid payment_id UUID format
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/social/unlike:
     delete:
@@ -853,11 +941,15 @@ paths:
         '400':
           description: Invalid payment_id UUID format
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/social/comment:
     post:
@@ -883,11 +975,15 @@ paths:
         '400':
           description: Invalid payment_id UUID format
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/social/comment/{id}:
     delete:
@@ -914,17 +1010,21 @@ paths:
         '400':
           description: Invalid UUID format for comment id
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Comment not found or not owned by authenticated user
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/bridge/quote:
     post:
@@ -948,15 +1048,15 @@ paths:
         '400':
           description: Missing required fields or invalid amount
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '502':
           description: Allbridge upstream API failure
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/bridge/tx:
     post:
@@ -980,15 +1080,15 @@ paths:
         '400':
           description: source_tx_hash is empty
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error during DB insertion
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/bridge/status/{id}:
     get:
@@ -1013,12 +1113,12 @@ paths:
         '404':
           description: Bridge transaction not found
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ErrorResponse'

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -92,9 +92,6 @@ components:
         display_name:
           type: string
           nullable: true
-        bio:
-          type: string
-          nullable: true
         avatar_url:
           type: string
           nullable: true
@@ -103,9 +100,6 @@ components:
       type: object
       properties:
         display_name:
-          type: string
-          nullable: true
-        bio:
           type: string
           nullable: true
         avatar_url:
@@ -118,12 +112,6 @@ components:
         q:
           type: string
           description: Search term matched against username and address via ILIKE
-        limit:
-          type: integer
-          default: 20
-        offset:
-          type: integer
-          default: 0
 
     SearchUser:
       type: object
@@ -163,21 +151,12 @@ components:
       properties:
         status:
           type: string
-          description: Status of the friendship request or action result
           enum:
-            - PENDING
-            - ACCEPTED
-            - REJECTED
+            - pending
 
     FeedQuery:
       type: object
       properties:
-        limit:
-          type: integer
-          default: 20
-        offset:
-          type: integer
-          default: 0
 
     FeedItem:
       type: object
@@ -232,18 +211,10 @@ components:
       type: object
       required:
         - success
-        - likes_count
-        - has_liked
       properties:
         success:
           type: boolean
-          description: true if the like was recorded or unliked successfully
-        likes_count:
-          type: integer
-          description: Total number of likes on the payment after the action
-        has_liked:
-          type: boolean
-          description: true if the requesting user currently likes the payment
+          description: true if the like/unlike action succeeded
 
     CommentRequest:
       type: object
@@ -339,77 +310,30 @@ components:
         source_tx_hash:
           type: string
           description: Source chain transaction hash of the deposit
-        source_chain:
-          type: string
-          description: Source chain; defaults to STLR if omitted
-          default: STLR
-        destination_chain:
-          type: string
-          description: Target chain, or null if unknown
-          nullable: true
-        destination_address:
-          type: string
-          description: Receiver address on the destination chain
-          nullable: true
-        amount:
-          type: string
-          description: Deposit amount tracking
-          nullable: true
 
     BridgeTxResponse:
       type: object
       required:
-        - id
-        - source_tx_hash
         - status
       properties:
-        id:
-          type: string
-          description: UUID of the bridge transaction record
-        source_tx_hash:
-          type: string
-          description: Source chain transaction hash
         status:
           type: string
           enum:
-            - PENDING
-            - SUCCESS
-            - FAILED
+            - submitted
 
     BridgeStatusResponse:
       type: object
       required:
-        - source_tx_hash
-        - source_chain
         - status
         - confirmations
-        - updated_at
       properties:
-        source_tx_hash:
-          type: string
-          description: Source chain transaction hash
-        source_chain:
-          type: string
-          description: Origin chain code
-          enum:
-            - STLR
-        destination_chain:
-          type: string
-          nullable: true
-          description: Destination chain; null if not yet determined
         status:
           type: string
           enum:
-            - PENDING
-            - SUCCESS
-            - FAILED
+            - completed
         confirmations:
           type: integer
           description: Number of confirmations observed on the source chain
-        updated_at:
-          type: string
-          format: date-time
-          description: ISO8601 timestamp of last status update
 
 paths:
   /health:
@@ -666,88 +590,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /api/users/friends/{id}/accept:
-    post:
-      tags:
-        - Users
-      summary: Accept an incoming friend request
-      operationId: acceptFriendRequest
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: UUID of the friendship record to accept
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Friend request accepted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StatusResponse'
-        '400':
-          description: Invalid UUID format for friendship id
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
-          description: Pending friend request not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /api/users/friends/{id}/reject:
-    post:
-      tags:
-        - Users
-      summary: Reject an incoming friend request
-      operationId: rejectFriendRequest
-      security:
-        - BearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: UUID of the friendship record to reject
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Friend request rejected
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StatusResponse'
-        '400':
-          description: Invalid UUID format for friendship id
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
-          description: Pending friend request not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
   /api/feed/public:
     get:
       tags:
@@ -756,21 +598,6 @@ paths:
       operationId: getPublicFeed
       security:
         - BearerAuth: []
-      parameters:
-        - name: limit
-          in: query
-          required: false
-          description: Maximum number of items to return
-          schema:
-            type: integer
-            default: 20
-        - name: offset
-          in: query
-          required: false
-          description: Number of items to skip
-          schema:
-            type: integer
-            default: 0
       responses:
         '200':
           description: Public feed items
@@ -801,21 +628,6 @@ paths:
       operationId: getFriendsFeed
       security:
         - BearerAuth: []
-      parameters:
-        - name: limit
-          in: query
-          required: false
-          description: Maximum number of items to return
-          schema:
-            type: integer
-            default: 20
-        - name: offset
-          in: query
-          required: false
-          description: Number of items to skip
-          schema:
-            type: integer
-            default: 0
       responses:
         '200':
           description: Friends feed items (PUBLIC and FRIENDS visibility)
@@ -846,21 +658,6 @@ paths:
       operationId: getPrivateFeed
       security:
         - BearerAuth: []
-      parameters:
-        - name: limit
-          in: query
-          required: false
-          description: Maximum number of items to return
-          schema:
-            type: integer
-            default: 20
-        - name: offset
-          in: query
-          required: false
-          description: Number of items to skip
-          schema:
-            type: integer
-            default: 0
       responses:
         '200':
           description: Private feed items where the user is sender or receiver

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1,0 +1,1024 @@
+openapi: 3.0.3
+info:
+  title: Zaps Backend API
+  description: Backend API for the Zaps social payments platform on Stellar. Covers auth, profiles, feed, social interactions, and cross-chain token bridging.
+  version: 1.0.0
+  contact:
+    name: Fracverse
+
+servers:
+  - url: http://localhost:8080
+    description: Development server
+
+tags:
+  - name: Auth
+    description: Challenge issuance and Stellar signature verification for JWT auth
+  - name: Users
+    description: User profiles, search, and friend management
+  - name: Feed
+    description: Public, friends, and private payment feeds
+  - name: Social
+    description: Likes and comments on payments
+  - name: Bridge
+    description: Cross-chain token quote, submission, and status tracking
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT obtained from POST /api/auth/verify
+
+  schemas:
+    ChallengeResponse:
+      type: object
+      required:
+        - challenge
+      properties:
+        challenge:
+          type: string
+          description: UUID v4 challenge string to be signed by the client Stellar keypair
+
+    VerifyRequest:
+      type: object
+      required:
+        - address
+        - signature
+        - challenge
+      properties:
+        address:
+          type: string
+          description: Stellar G... public address
+        signature:
+          type: string
+          description: Hex or base64-encoded Ed25519 signature of the challenge bytes
+        challenge:
+          type: string
+          description: Challenge string previously obtained from GET /api/auth/challenge
+
+    VerifyResponse:
+      type: object
+      required:
+        - token
+        - username
+      properties:
+        token:
+          type: string
+          description: JWT valid for 24 hours; include as Authorization: Bearer header
+        username:
+          type: string
+          description: Auto-generated username prefixed with u_ followed by chars 2-15 of the Stellar address
+
+    ProfileResponse:
+      type: object
+      properties:
+        address:
+          type: string
+        username:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        bio:
+          type: string
+          nullable: true
+        avatar_url:
+          type: string
+          nullable: true
+
+    UpdateProfileRequest:
+      type: object
+      properties:
+        display_name:
+          type: string
+          nullable: true
+        bio:
+          type: string
+          nullable: true
+        avatar_url:
+          type: string
+          nullable: true
+
+    SearchQuery:
+      type: object
+      properties:
+        q:
+          type: string
+          description: Search term matched against username and address (ILIKE)
+        limit:
+          type: integer
+          description: Max results to return
+          default: 20
+        offset:
+          type: integer
+          description: Result offset for pagination
+          default: 0
+
+    SearchUser:
+      type: object
+      properties:
+        username:
+          type: string
+        address:
+          type: string
+        avatar_url:
+          type: string
+          nullable: true
+
+    FriendUser:
+      type: object
+      properties:
+        username:
+          type: string
+        address:
+          type: string
+        avatar_url:
+          type: string
+          nullable: true
+
+    FriendRequest:
+      type: object
+      required:
+        - friend_address
+      properties:
+        friend_address:
+          type: string
+          description: Stellar G... address of the user to befriend
+
+    StatusResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - PENDING
+            - ACCEPTED
+            - REJECTED
+
+    FeedQuery:
+      type: object
+      properties:
+        limit:
+          type: integer
+          default: 20
+        offset:
+          type: integer
+          default: 0
+
+    FeedItem:
+      type: object
+      properties:
+        id:
+          type: string
+          description: UUID of the payment record
+        tx_hash:
+          type: string
+          description: Stellar transaction hash
+        sender_username:
+          type: string
+        sender_avatar:
+          type: string
+          nullable: true
+        receiver_username:
+          type: string
+        receiver_avatar:
+          type: string
+          nullable: true
+        amount:
+          type: string
+          description: Payment amount as a fixed-precision string
+        currency:
+          type: string
+          description: Payment currency code (NGN or USDC)
+        memo:
+          type: string
+          description: Optional payment memo
+        likes_count:
+          type: integer
+        comments_count:
+          type: integer
+        has_liked:
+          type: boolean
+          description: Whether the requesting user has liked this payment (always false for anonymous requests)
+        created_at:
+          type: string
+          format: date-time
+          description: ISO8601 / RFC3339 timestamp
+
+    LikeRequest:
+      type: object
+      required:
+        - payment_id
+      properties:
+        payment_id:
+          type: string
+          description: UUID of the payment record to like or unlike
+
+    LikeResponse:
+      type: object
+      required:
+        - success
+        - likes_count
+        - has_liked
+      properties:
+        success:
+          type: boolean
+        likes_count:
+          type: integer
+        has_liked:
+          type: boolean
+
+    CommentRequest:
+      type: object
+      required:
+        - payment_id
+        - content
+      properties:
+        payment_id:
+          type: string
+          description: UUID of the payment record to comment on
+        content:
+          type: string
+          description: Comment text
+
+    CommentResponse:
+      type: object
+      required:
+        - id
+        - username
+        - content
+        - created_at
+      properties:
+        id:
+          type: string
+          description: UUID of the comment
+        username:
+          type: string
+        content:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+
+    DeleteCommentResponse:
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+
+    BridgeQuoteRequest:
+      type: object
+      required:
+        - source_chain
+        - source_token
+        - amount
+        - destination_chain
+        - destination_token
+        - destination_address
+      properties:
+        source_chain:
+          type: string
+          enum:
+            - STLR
+            - ETH
+            - BSC
+          description: Origin chain code
+        source_token:
+          type: string
+          description: Source token contract address
+        amount:
+          type: string
+          description: Positive integer string representing token amount
+        destination_chain:
+          type: string
+          enum:
+            - STLR
+            - ETH
+            - BSC
+          description: Target chain code
+        destination_token:
+          type: string
+          description: Destination token contract address
+        destination_address:
+          type: string
+          description: Stellar or EVM address to receive the bridged funds
+
+    BridgeQuoteResponse:
+      type: object
+      required:
+        - fee
+        - receive_amount
+        - bridge_tx_data
+      properties:
+        fee:
+          type: string
+          description: Bridge fee amount
+        receive_amount:
+          type: string
+          description: Net amount receiver will get after fees
+        bridge_tx_data:
+          type: string
+          description: Serialized transaction data or instructions provided by the bridge provider
+
+    BridgeTxRequest:
+      type: object
+      required:
+        - source_tx_hash
+      properties:
+        source_tx_hash:
+          type: string
+          description: Source chain transaction hash of the deposit
+        source_chain:
+          type: string
+          description: Source chain; defaults to STLR if omitted
+          enum:
+            - STLR
+        destination_chain:
+          type: string
+          description: Target chain, or null if unknown
+          nullable: true
+          enum:
+            - ETH
+            - BSC
+        destination_address:
+          type: string
+          description: Receiver address on the destination chain
+          nullable: true
+        amount:
+          type: string
+          description: Deposit amount tracking
+          nullable: true
+
+    BridgeTxResponse:
+      type: object
+      required:
+        - id
+        - source_tx_hash
+        - status
+      properties:
+        id:
+          type: string
+          description: UUID of the bridge transaction record
+        source_tx_hash:
+          type: string
+        status:
+          type: string
+          enum:
+            - PENDING
+            - SUCCESS
+            - FAILED
+
+    BridgeStatusResponse:
+      type: object
+      required:
+        - source_tx_hash
+        - source_chain
+        - status
+        - confirmations
+        - updated_at
+      properties:
+        source_tx_hash:
+          type: string
+        source_chain:
+          type: string
+          enum:
+            - STLR
+        destination_chain:
+          type: string
+          nullable: true
+          description: Destination chain; null if not yet determined
+          enum:
+            - ETH
+            - BSC
+        status:
+          type: string
+          enum:
+            - PENDING
+            - SUCCESS
+            - FAILED
+        confirmations:
+          type: integer
+          description: Number of confirmations observed on the source chain
+        updated_at:
+          type: string
+          format: date-time
+
+paths:
+  /health:
+    get:
+      tags:
+        - Auth
+      summary: Health check endpoint
+      operationId: healthCheck
+      responses:
+        '200':
+          description: Server is healthy
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: OK
+
+  /api/auth/challenge:
+    get:
+      tags:
+        - Auth
+      summary: Get a Stellar signing challenge
+      operationId: getChallenge
+      responses:
+        '200':
+          description: Challenge UUID to sign
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChallengeResponse'
+              example:
+                challenge: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+  /api/auth/verify:
+    post:
+      tags:
+        - Auth
+      summary: Verify a Stellar signature and issue a JWT
+      operationId: verifySignature
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyRequest'
+      responses:
+        '200':
+          description: Signature verified; JWT returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyResponse'
+        '400':
+          description: Invalid signature format
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Invalid signature format (must be hex or base64)
+        '401':
+          description: Signature verification failed
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Signature verification failed
+        '500':
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /api/users/profile:
+    get:
+      tags:
+        - Users
+      summary: Get the authenticated user profile
+      operationId: getProfile
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: User profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProfileResponse'
+        '401':
+          description: Missing or invalid JWT
+          content:
+            text/plain:
+              schema:
+                type: string
+
+    post:
+      tags:
+        - Users
+      summary: Update the authenticated user profile
+      operationId: updateProfile
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProfileRequest'
+      responses:
+        '200':
+          description: Updated profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProfileResponse'
+        '401':
+          description: Missing or invalid JWT
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /api/users/search:
+    get:
+      tags:
+        - Users
+      summary: Search users by username or address
+      operationId: searchUsers
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search term matched against username and address
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of results
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          description: Result offset for pagination
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Matching users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SearchUser'
+        '401':
+          description: Missing or invalid JWT
+
+  /api/users/friends:
+    get:
+      tags:
+        - Users
+      summary: List accepted friends of the authenticated user
+      operationId: listFriends
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: List of friends
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FriendUser'
+        '401':
+          description: Missing or invalid JWT
+
+    post:
+      tags:
+        - Users
+        - Social
+      summary: Send a friend request
+      operationId: sendFriendRequest
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FriendRequest'
+      responses:
+        '201':
+          description: Friend request created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          description: Cannot friend yourself
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Target user not found
+          content:
+            text/plain:
+              schema:
+                type: string
+        '409':
+          description: Friendship already exists
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+
+  /api/users/friends/{id}/accept:
+    post:
+      tags:
+        - Users
+      summary: Accept a pending friend request
+      operationId: acceptFriendRequest
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: UUID of the friendship record
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Friend request accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '404':
+          description: No pending request found for this friendship ID
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+
+  /api/users/friends/{id}/reject:
+    post:
+      tags:
+        - Users
+      summary: Reject a pending friend request
+      operationId: rejectFriendRequest
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: UUID of the friendship record
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Friend request rejected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '404':
+          description: No pending request found for this friendship ID
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+
+  /api/feed/public:
+    get:
+      tags:
+        - Feed
+      summary: Get the public payment feed
+      operationId: getPublicFeed
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of items to return
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          description: Result offset for pagination
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Public feed items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FeedItem'
+        '401':
+          description: Missing or invalid JWT
+
+  /api/feed/friends:
+    get:
+      tags:
+        - Feed
+      summary: Get the friends payment feed
+      operationId: getFriendsFeed
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of items to return
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          description: Result offset for pagination
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Friends feed items (PUBLIC and FRIENDS visibility)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FeedItem'
+        '401':
+          description: Missing or invalid JWT
+
+  /api/feed/private:
+    get:
+      tags:
+        - Feed
+      summary: Get the private payment feed for the authenticated user
+      operationId: getPrivateFeed
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of items to return
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          description: Result offset for pagination
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Private feed items where the user is sender or receiver
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FeedItem'
+        '401':
+          description: Missing or invalid JWT
+
+  /api/social/like:
+    post:
+      tags:
+        - Social
+      summary: Like a payment
+      operationId: likePayment
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LikeRequest'
+      responses:
+        '200':
+          description: Like recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LikeResponse'
+        '400':
+          description: Invalid payment_id UUID format
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+
+  /api/social/unlike:
+    delete:
+      tags:
+        - Social
+      summary: Unlike a payment
+      operationId: unlikePayment
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LikeRequest'
+      responses:
+        '200':
+          description: Like removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LikeResponse'
+        '400':
+          description: Invalid payment_id UUID format
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+
+  /api/social/comment:
+    post:
+      tags:
+        - Social
+      summary: Add a comment to a payment
+      operationId: addComment
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommentRequest'
+      responses:
+        '200':
+          description: Comment created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommentResponse'
+        '400':
+          description: Invalid payment_id UUID format
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+
+  /api/social/comment/{id}:
+    delete:
+      tags:
+        - Social
+      summary: Delete a comment by ID
+      operationId: deleteComment
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: UUID string of the comment to delete
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Comment deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteCommentResponse'
+        '400':
+          description: Invalid UUID format for comment id
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Comment not found or not owned by authenticated user
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+
+  /api/bridge/quote:
+    post:
+      tags:
+        - Bridge
+      summary: Get a cross-chain bridge quote from Allbridge
+      operationId: getBridgeQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BridgeQuoteRequest'
+      responses:
+        '200':
+          description: Bridge quote from upstream provider
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BridgeQuoteResponse'
+        '400':
+          description: Missing required fields or invalid amount
+          content:
+            text/plain:
+              schema:
+                type: string
+        '502':
+          description: Allbridge upstream API failure
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /api/bridge/tx:
+    post:
+      tags:
+        - Bridge
+      summary: Submit a bridge transaction record
+      operationId: submitBridgeTx
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BridgeTxRequest'
+      responses:
+        '200':
+          description: Bridge transaction record created or updated (idempotent)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BridgeTxResponse'
+        '400':
+          description: source_tx_hash is empty
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error during DB insertion
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /api/bridge/status/{id}:
+    get:
+      tags:
+        - Bridge
+      summary: Get bridge transaction status by source TX hash
+      operationId: getBridgeStatus
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Source chain transaction hash (source_tx_hash)
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Bridge transaction status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BridgeStatusResponse'
+        '404':
+          description: Bridge transaction not found
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string


### PR DESCRIPTION
## Summary
Adds `docs/openapi.yaml`, an OpenAPI v3 specification covering all backend routes — Auth, Profile, Feed, Social, and Bridge — per the acceptance criteria in #333.

## Approach
- Paths and prefixes match what's actually registered in mod.rs, not just the issue description.
- Request/response schemas are derived from the real handler structs and mock responses rather than assumed/aspirational fields.
- One route doesn't follow typical REST conventions — `DELETE /api/social/unlike` takes a JSON body — documented as-is since that's what the code does.

## Verification
- Cross-checked every path and schema against the actual route handlers (mod.rs, auth.rs, user.rs, feed.rs, social.rs, bridge.rs) rather than relying on the issue description alone.
- Validated the YAML parses cleanly as OpenAPI 3.0.

Closes #333