### PR TITLE
feat(home): style Earning Balance card with 'Your money is working' status

### DIFF
--- a/mobileapp/app/(personal)/home.tsx
+++ b/mobileapp/app/(personal)/home.tsx
@@ -360,10 +360,15 @@ export default function HomeScreen() {
           <View>
             <Text style={styles.earningLabel}>Earning Balance</Text>
             <Text style={styles.earningAmount}>{totalYieldEarned}</Text>
-            <Text style={styles.earningHint}>Tap to view yield breakdown</Text>
+            <View style={styles.earningStatusRow}>
+              <View style={styles.earningStatusDot} />
+              <Text style={styles.earningStatusText}>
+                Your money is working
+              </Text>
+            </View>
           </View>
           <View style={styles.earningIconWrap}>
-            <Ionicons name="trending-up" size={20} color={COLORS.primary} />
+            <Ionicons name="trending-up" size={20} color="#A7F3C0" />
           </View>
         </TouchableOpacity>
 
@@ -724,39 +729,53 @@ const styles = StyleSheet.create({
     marginTop: 12,
   },
   earningBalanceCard: {
-    backgroundColor: "#EEF7EA",
+    backgroundColor: "#0F3D2E",
     borderRadius: 22,
-    borderWidth: 1,
-    borderColor: "#D7EACF",
-    paddingVertical: 16,
-    paddingHorizontal: 16,
+    paddingVertical: 18,
+    paddingHorizontal: 18,
     marginBottom: 8,
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
+    shadowColor: "#0F3D2E",
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.18,
+    shadowRadius: 16,
+    elevation: 3,
   },
   earningLabel: {
     fontSize: 13,
     fontFamily: "Outfit_500Medium",
-    color: "#456047",
+    color: "#9FD9B5",
     marginBottom: 6,
   },
   earningAmount: {
     fontSize: 24,
     fontFamily: "Outfit_700Bold",
-    color: COLORS.primary,
-    marginBottom: 2,
+    color: COLORS.white,
+    marginBottom: 8,
   },
-  earningHint: {
+  earningStatusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  earningStatusDot: {
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+    backgroundColor: "#34D399",
+    marginRight: 7,
+  },
+  earningStatusText: {
     fontSize: 12,
-    fontFamily: "Outfit_400Regular",
-    color: "#56785A",
+    fontFamily: "Outfit_500Medium",
+    color: "#BFE9CF",
   },
   earningIconWrap: {
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: "#DDEFD5",
+    backgroundColor: "rgba(167, 243, 192, 0.14)",
     justifyContent: "center",
     alignItems: "center",
   },


### PR DESCRIPTION
## Summary
Applies a premium, minimalist dark-green treatment to the Earning Balance card and adds a **"Your money is working"** sub-text with an active status dot, signalling that yield is actively accruing. Heavy borders removed in favour of a soft elevated shadow.

## Validation
- `prettier --check` ✓
- `eslint --max-warnings 0` ✓

Closes #388