### PR TITLE
[377][378][379][380] [BE-029–BE-032] Auto-sweep worker, yield calculator, toggle API, and report notifications

### DIFF
--- a/backend/migrations/20260627000000_yield_auto_earn_and_notifications.sql
+++ b/backend/migrations/20260627000000_yield_auto_earn_and_notifications.sql
@@ -1,0 +1,28 @@
+-- BE-030: auto-earn preference on user profile
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS auto_earn_enabled BOOLEAN NOT NULL DEFAULT false;
+
+-- BE-031: track last on-chain / indexer sync for off-chain yield estimates
+ALTER TABLE user_yield_balances
+    ADD COLUMN IF NOT EXISTS last_yield_sync_at TIMESTAMP NOT NULL DEFAULT NOW();
+
+-- BE-032: Expo push tokens for yield report notifications
+CREATE TABLE IF NOT EXISTS user_push_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expo_push_token TEXT NOT NULL,
+    platform VARCHAR(20),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, expo_push_token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_push_tokens_user_id ON user_push_tokens(user_id);
+
+-- BE-032: throttle daily/weekly yield report notifications per user
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS last_daily_yield_report_at TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS last_weekly_yield_report_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_users_auto_earn ON users(auto_earn_enabled)
+    WHERE auto_earn_enabled = true;

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -62,5 +62,6 @@ pub fn yield_routes(pool: sqlx::PgPool) -> Router {
         .route("/history", get(r#yield::get_history))
         .route("/deposit", post(r#yield::deposit))
         .route("/withdraw", post(r#yield::withdraw))
+        .route("/toggle-auto", post(r#yield::toggle_auto_earn))
         .with_state(pool)
 }

--- a/backend/src/api/yield.rs
+++ b/backend/src/api/yield.rs
@@ -6,9 +6,12 @@ use axum::{
     Json,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 use uuid::Uuid;
+
+use crate::services::yield_calc;
 
 // ── #373 — GET /api/yield/balance ─────────────────────────────────────────
 
@@ -16,8 +19,13 @@ use uuid::Uuid;
 pub struct YieldBalanceResponse {
     pub available_balance: i64,
     pub earning_balance: i64,
+    /// Interest accrued since the last on-chain sync (micro-units).
+    pub accrued_interest: i64,
+    /// Earning balance including live accrued interest.
+    pub total_earning_balance: i64,
     /// Current APY as a percentage (e.g., 5.0 for 5%).
     pub apy: f64,
+    pub auto_earn_enabled: bool,
 }
 
 pub async fn get_balance(State(pool): State<sqlx::PgPool>, auth: AuthUser) -> impl IntoResponse {
@@ -46,10 +54,28 @@ pub async fn get_balance(State(pool): State<sqlx::PgPool>, auth: AuthUser) -> im
         }
     };
 
+    let estimate = yield_calc::estimate_for_balance(&balance, Some(apy_bps), Utc::now());
+
+    let auto_earn_enabled =
+        match crate::db::r#yield::get_auto_earn_enabled(&pool, auth.id).await {
+            Ok(enabled) => enabled,
+            Err(e) => {
+                tracing::error!("auto-earn preference fetch error: {:?}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": "Failed to retrieve auto-earn preference" })),
+                )
+                    .into_response();
+            }
+        };
+
     Json(YieldBalanceResponse {
         available_balance: balance.available_balance,
         earning_balance: balance.earning_balance,
+        accrued_interest: estimate.accrued_interest,
+        total_earning_balance: estimate.total_earning_balance,
         apy: apy_bps as f64 / 100.0,
+        auto_earn_enabled,
     })
     .into_response()
 }
@@ -155,6 +181,46 @@ pub async fn get_history(
     .into_response()
 }
 
+// ── #378 — POST /api/yield/toggle-auto ────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ToggleAutoEarnRequest {
+    pub enabled: bool,
+}
+
+#[derive(Serialize)]
+pub struct ToggleAutoEarnResponse {
+    pub auto_earn_enabled: bool,
+    pub message: String,
+}
+
+pub async fn toggle_auto_earn(
+    State(pool): State<sqlx::PgPool>,
+    auth: AuthUser,
+    Json(payload): Json<ToggleAutoEarnRequest>,
+) -> impl IntoResponse {
+    match crate::db::r#yield::set_auto_earn_enabled(&pool, auth.id, payload.enabled).await {
+        Ok(enabled) => Json(ToggleAutoEarnResponse {
+            auto_earn_enabled: enabled,
+            message: if enabled {
+                "Auto-earn enabled. Idle stablecoins will be swept into the yield vault."
+                    .to_string()
+            } else {
+                "Auto-earn disabled.".to_string()
+            },
+        })
+        .into_response(),
+        Err(e) => {
+            tracing::error!("toggle auto-earn error: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to update auto-earn preference" })),
+            )
+                .into_response()
+        }
+    }
+}
+
 // ── #375 — POST /api/yield/deposit ────────────────────────────────────────
 
 #[derive(Deserialize)]
@@ -243,6 +309,7 @@ pub async fn deposit(
             ON CONFLICT (user_id) DO UPDATE
             SET available_balance = user_yield_balances.available_balance - $2,
                 earning_balance   = user_yield_balances.earning_balance   + $2,
+                last_yield_sync_at  = NOW(),
                 updated_at        = NOW()
             "#,
         )

--- a/backend/src/db/models.rs
+++ b/backend/src/db/models.rs
@@ -10,6 +10,7 @@ pub struct User {
     pub display_name: Option<String>,
     pub bio: Option<String>,
     pub avatar_url: Option<String>,
+    pub auto_earn_enabled: bool,
     pub created_at: NaiveDateTime,
 }
 
@@ -71,6 +72,7 @@ pub struct UserYieldBalance {
     pub user_id: Uuid,
     pub available_balance: i64,
     pub earning_balance: i64,
+    pub last_yield_sync_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }
 

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -8,6 +8,9 @@ CREATE TABLE IF NOT EXISTS users (
     display_name VARCHAR(100),
     bio VARCHAR(255),
     avatar_url TEXT,
+    auto_earn_enabled BOOLEAN NOT NULL DEFAULT false,
+    last_daily_yield_report_at TIMESTAMP,
+    last_weekly_yield_report_at TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
@@ -75,7 +78,18 @@ CREATE TABLE IF NOT EXISTS user_yield_balances (
     user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
     available_balance BIGINT NOT NULL DEFAULT 0 CHECK (available_balance >= 0),
     earning_balance BIGINT NOT NULL DEFAULT 0 CHECK (earning_balance >= 0),
+    last_yield_sync_at TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS user_push_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expo_push_token TEXT NOT NULL,
+    platform VARCHAR(20),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, expo_push_token)
 );
 
 CREATE TABLE IF NOT EXISTS yield_transactions (

--- a/backend/src/db/yield.rs
+++ b/backend/src/db/yield.rs
@@ -12,7 +12,7 @@ pub async fn get_or_create_yield_balance(
         INSERT INTO user_yield_balances (user_id, available_balance, earning_balance, updated_at)
         VALUES ($1, 0, 0, NOW())
         ON CONFLICT (user_id) DO UPDATE SET updated_at = NOW()
-        RETURNING user_id, available_balance, earning_balance, updated_at
+        RETURNING user_id, available_balance, earning_balance, last_yield_sync_at, updated_at
         "#,
     )
     .bind(user_id)
@@ -23,6 +23,7 @@ pub async fn get_or_create_yield_balance(
         user_id: row.get("user_id"),
         available_balance: row.get("available_balance"),
         earning_balance: row.get("earning_balance"),
+        last_yield_sync_at: row.get("last_yield_sync_at"),
         updated_at: row.get("updated_at"),
     })
 }
@@ -69,6 +70,7 @@ pub async fn process_yield_deposit_tx(
         VALUES ($1, 0, $2, NOW())
         ON CONFLICT (user_id) DO UPDATE 
         SET earning_balance = user_yield_balances.earning_balance + $2,
+            last_yield_sync_at = NOW(),
             updated_at = NOW()
         "#,
     )
@@ -122,6 +124,7 @@ pub async fn process_yield_withdrawal_tx(
         UPDATE user_yield_balances
         SET earning_balance = earning_balance - $2,
             available_balance = available_balance + $2,
+            last_yield_sync_at = NOW(),
             updated_at = NOW()
         WHERE user_id = $1
         "#,
@@ -162,4 +165,135 @@ pub async fn get_current_yield_rate(pool: &PgPool) -> Result<Option<i32>, sqlx::
     .await?;
 
     Ok(rate)
+}
+
+/// Read whether the user has auto-earn (auto-sweep) enabled.
+pub async fn get_auto_earn_enabled(pool: &PgPool, user_id: Uuid) -> Result<bool, sqlx::Error> {
+    let enabled = sqlx::query_scalar(
+        r#"
+        SELECT auto_earn_enabled FROM users WHERE id = $1
+        "#,
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(enabled)
+}
+
+/// Persist auto-earn preference on the user's profile row.
+pub async fn set_auto_earn_enabled(
+    pool: &PgPool,
+    user_id: Uuid,
+    enabled: bool,
+) -> Result<bool, sqlx::Error> {
+    let updated = sqlx::query_scalar(
+        r#"
+        UPDATE users
+        SET auto_earn_enabled = $2
+        WHERE id = $1
+        RETURNING auto_earn_enabled
+        "#,
+    )
+    .bind(user_id)
+    .bind(enabled)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(updated)
+}
+
+/// Users with auto-earn on and idle available balance above `min_amount`.
+pub async fn list_auto_sweep_candidates(
+    pool: &PgPool,
+    min_amount: i64,
+    limit: i64,
+) -> Result<Vec<UserYieldBalance>, sqlx::Error> {
+    let rows = sqlx::query(
+        r#"
+        SELECT b.user_id, b.available_balance, b.earning_balance, b.last_yield_sync_at, b.updated_at
+        FROM user_yield_balances b
+        JOIN users u ON u.id = b.user_id
+        WHERE u.auto_earn_enabled = true
+          AND b.available_balance >= $1
+        ORDER BY b.updated_at ASC
+        LIMIT $2
+        "#,
+    )
+    .bind(min_amount)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| UserYieldBalance {
+            user_id: row.get("user_id"),
+            available_balance: row.get("available_balance"),
+            earning_balance: row.get("earning_balance"),
+            last_yield_sync_at: row.get("last_yield_sync_at"),
+            updated_at: row.get("updated_at"),
+        })
+        .collect())
+}
+
+/// Move idle available balance into earning (off-chain auto-sweep).
+pub async fn process_internal_sweep_deposit(
+    pool: &PgPool,
+    user_id: Uuid,
+    amount: i64,
+    tx_hash: &str,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO yield_transactions (user_id, tx_hash, type, amount, created_at)
+        VALUES ($1, $2, 'DEPOSIT', $3, NOW())
+        "#,
+    )
+    .bind(user_id)
+    .bind(tx_hash)
+    .bind(amount)
+    .execute(&mut *tx)
+    .await?;
+
+    let updated = sqlx::query(
+        r#"
+        UPDATE user_yield_balances
+        SET available_balance = available_balance - $2,
+            earning_balance = earning_balance + $2,
+            last_yield_sync_at = NOW(),
+            updated_at = NOW()
+        WHERE user_id = $1
+          AND available_balance >= $2
+        "#,
+    )
+    .bind(user_id)
+    .bind(amount)
+    .execute(&mut *tx)
+    .await?;
+
+    if updated.rows_affected() == 0 {
+        return Err(sqlx::Error::RowNotFound);
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Touch the yield sync timestamp after an on-chain balance update.
+pub async fn touch_yield_sync_at(pool: &PgPool, user_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        UPDATE user_yield_balances
+        SET last_yield_sync_at = NOW(), updated_at = NOW()
+        WHERE user_id = $1
+        "#,
+    )
+    .bind(user_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -196,6 +196,20 @@ async fn main() {
         api::bridge::run_status_poller(bridge_state).await;
     });
 
+    // BE-029: Auto-sweep idle stablecoins for users with auto-earn enabled.
+    let sweep_pool = pool.clone();
+    let sweep_config = services::sweep_worker::SweepWorkerConfig::from_env();
+    tokio::spawn(async move {
+        services::sweep_worker::run(sweep_pool, sweep_config).await;
+    });
+
+    // BE-032: Daily / weekly yield report push notifications.
+    let notification_pool = pool.clone();
+    let notification_config = services::notifications::NotificationSchedulerConfig::from_env();
+    tokio::spawn(async move {
+        services::notifications::run(notification_pool, notification_config).await;
+    });
+
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
     tracing::info!("Listening on {}", addr);
 

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,2 +1,5 @@
 pub mod allbridge;
+pub mod notifications;
 pub mod stellar;
+pub mod sweep_worker;
+pub mod yield_calc;

--- a/backend/src/services/notifications.rs
+++ b/backend/src/services/notifications.rs
@@ -1,0 +1,340 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::Serialize;
+use serde_json::json;
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use crate::db::r#yield::get_current_yield_rate;
+use crate::services::yield_calc::SECONDS_PER_YEAR;
+
+const EXPO_PUSH_URL: &str = "https://exp.host/--/api/v2/push/send";
+const DEFAULT_YIELD_REPORT_THRESHOLD: i64 = 1_000;
+const DEFAULT_DAILY_INTERVAL_SECS: u64 = 86_400;
+const DEFAULT_WEEKLY_INTERVAL_SECS: u64 = 604_800;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum YieldReportCadence {
+    Daily,
+    Weekly,
+}
+
+pub struct NotificationSchedulerConfig {
+    pub daily_interval: std::time::Duration,
+    pub weekly_interval: std::time::Duration,
+    pub yield_threshold: i64,
+    pub expo_access_token: Option<String>,
+}
+
+impl NotificationSchedulerConfig {
+    pub fn from_env() -> Self {
+        let daily_secs = std::env::var("YIELD_REPORT_DAILY_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_DAILY_INTERVAL_SECS);
+        let weekly_secs = std::env::var("YIELD_REPORT_WEEKLY_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_WEEKLY_INTERVAL_SECS);
+        let threshold = std::env::var("YIELD_REPORT_THRESHOLD")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_YIELD_REPORT_THRESHOLD);
+
+        Self {
+            daily_interval: std::time::Duration::from_secs(daily_secs),
+            weekly_interval: std::time::Duration::from_secs(weekly_secs),
+            yield_threshold: threshold,
+            expo_access_token: std::env::var("EXPO_ACCESS_TOKEN").ok(),
+        }
+    }
+}
+
+struct YieldReportCandidate {
+    user_id: Uuid,
+    username: String,
+    earning_balance: i64,
+    last_yield_sync_at: NaiveDateTime,
+    last_report_at: Option<NaiveDateTime>,
+    push_tokens: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ExpoPushMessage<'a> {
+    to: &'a str,
+    title: &'a str,
+    body: &'a str,
+    data: serde_json::Value,
+    sound: &'a str,
+}
+
+/// BE-032: Fire daily and weekly yield summary push notifications.
+pub async fn run(pool: PgPool, config: NotificationSchedulerConfig) {
+    tracing::info!("Starting yield report notification scheduler");
+
+    let daily_pool = pool.clone();
+    let daily_config = config.clone_for_worker();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(daily_config.daily_interval);
+        loop {
+            interval.tick().await;
+            if let Err(err) =
+                send_yield_reports(&daily_pool, &daily_config, YieldReportCadence::Daily).await
+            {
+                tracing::error!("Daily yield report scheduler failed: {err:?}");
+            }
+        }
+    });
+
+    let mut weekly_interval = tokio::time::interval(config.weekly_interval);
+    loop {
+        weekly_interval.tick().await;
+        if let Err(err) = send_yield_reports(&pool, &config, YieldReportCadence::Weekly).await {
+            tracing::error!("Weekly yield report scheduler failed: {err:?}");
+        }
+    }
+}
+
+impl NotificationSchedulerConfig {
+    fn clone_for_worker(&self) -> Self {
+        Self {
+            daily_interval: self.daily_interval,
+            weekly_interval: self.weekly_interval,
+            yield_threshold: self.yield_threshold,
+            expo_access_token: self.expo_access_token.clone(),
+        }
+    }
+}
+
+async fn send_yield_reports(
+    pool: &PgPool,
+    config: &NotificationSchedulerConfig,
+    cadence: YieldReportCadence,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let apy_bps = get_current_yield_rate(pool).await?.unwrap_or(500);
+    let candidates = load_report_candidates(pool, cadence).await?;
+    let now = Utc::now();
+
+    let mut sent = 0usize;
+    for candidate in candidates {
+        let period_start = candidate
+            .last_report_at
+            .unwrap_or(candidate.last_yield_sync_at);
+        let period_secs = (now - period_start.and_utc()).num_seconds().max(0);
+        if period_secs <= 0 {
+            continue;
+        }
+
+        let earned = estimate_period_yield(
+            candidate.earning_balance,
+            apy_bps,
+            period_secs,
+        );
+
+        if earned < config.yield_threshold {
+            continue;
+        }
+
+        let title = match cadence {
+            YieldReportCadence::Daily => "Your daily yield report",
+            YieldReportCadence::Weekly => "Your weekly yield report",
+        };
+        let body = format!(
+            "@{}, you earned {} micro-units in yield. Tap to view details.",
+            candidate.username, earned
+        );
+
+        for token in &candidate.push_tokens {
+            if let Err(err) = send_expo_push(
+                token,
+                title,
+                &body,
+                json!({
+                    "target": "home",
+                    "cadence": match cadence {
+                        YieldReportCadence::Daily => "daily",
+                        YieldReportCadence::Weekly => "weekly",
+                    },
+                    "earned": earned,
+                }),
+                config.expo_access_token.as_deref(),
+            )
+            .await
+            {
+                tracing::warn!(
+                    user_id = %candidate.user_id,
+                    error = ?err,
+                    "Failed to send yield report push notification"
+                );
+            }
+        }
+
+        mark_report_sent(pool, candidate.user_id, cadence, now).await?;
+        sent += 1;
+    }
+
+    tracing::info!(
+        cadence = ?cadence,
+        sent,
+        "Yield report notification cycle complete"
+    );
+    Ok(())
+}
+
+fn estimate_period_yield(earning_balance: i64, apy_bps: i32, period_secs: i64) -> i64 {
+    if earning_balance <= 0 || period_secs <= 0 {
+        return 0;
+    }
+
+    earning_balance
+        .saturating_mul(apy_bps as i64)
+        .saturating_mul(period_secs)
+        / (10_000 * SECONDS_PER_YEAR)
+}
+
+async fn load_report_candidates(
+    pool: &PgPool,
+    cadence: YieldReportCadence,
+) -> Result<Vec<YieldReportCandidate>, sqlx::Error> {
+    let report_column = match cadence {
+        YieldReportCadence::Daily => "u.last_daily_yield_report_at",
+        YieldReportCadence::Weekly => "u.last_weekly_yield_report_at",
+    };
+
+    let query = format!(
+        r#"
+        SELECT
+            u.id AS user_id,
+            u.username,
+            b.earning_balance,
+            b.last_yield_sync_at,
+            {report_column} AS last_report_at,
+            COALESCE(
+                array_agg(t.expo_push_token) FILTER (WHERE t.expo_push_token IS NOT NULL),
+                '{{}}'
+            ) AS push_tokens
+        FROM users u
+        JOIN user_yield_balances b ON b.user_id = u.id
+        LEFT JOIN user_push_tokens t ON t.user_id = u.id
+        WHERE b.earning_balance > 0
+        GROUP BY u.id, u.username, b.earning_balance, b.last_yield_sync_at, {report_column}
+        "#
+    );
+
+    let rows = sqlx::query(&query).fetch_all(pool).await?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let tokens: Option<Vec<String>> = row.try_get("push_tokens").ok();
+            let push_tokens: Vec<String> = tokens.unwrap_or_default();
+            if push_tokens.is_empty() {
+                return None;
+            }
+            Some(YieldReportCandidate {
+                user_id: row.get("user_id"),
+                username: row.get("username"),
+                earning_balance: row.get("earning_balance"),
+                last_yield_sync_at: row.get("last_yield_sync_at"),
+                last_report_at: row.get("last_report_at"),
+                push_tokens,
+            })
+        })
+        .collect())
+}
+
+async fn mark_report_sent(
+    pool: &PgPool,
+    user_id: Uuid,
+    cadence: YieldReportCadence,
+    now: DateTime<Utc>,
+) -> Result<(), sqlx::Error> {
+    let naive = now.naive_utc();
+    match cadence {
+        YieldReportCadence::Daily => {
+            sqlx::query(
+                "UPDATE users SET last_daily_yield_report_at = $2 WHERE id = $1",
+            )
+            .bind(user_id)
+            .bind(naive)
+            .execute(pool)
+            .await?;
+        }
+        YieldReportCadence::Weekly => {
+            sqlx::query(
+                "UPDATE users SET last_weekly_yield_report_at = $2 WHERE id = $1",
+            )
+            .bind(user_id)
+            .bind(naive)
+            .execute(pool)
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn send_expo_push(
+    token: &str,
+    title: &str,
+    body: &str,
+    data: serde_json::Value,
+    access_token: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let message = ExpoPushMessage {
+        to: token,
+        title,
+        body,
+        data,
+        sound: "default",
+    };
+
+    let mut request = reqwest::Client::new().post(EXPO_PUSH_URL).json(&message);
+    if let Some(token) = access_token.filter(|t| !t.is_empty()) {
+        request = request.bearer_auth(token);
+    }
+
+    let response = request.send().await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("Expo push API returned {status}: {text}").into());
+    }
+
+    Ok(())
+}
+
+/// Upsert an Expo push token for a user (used by mobile registration endpoint).
+pub async fn upsert_push_token(
+    pool: &PgPool,
+    user_id: Uuid,
+    token: &str,
+    platform: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO user_push_tokens (user_id, expo_push_token, platform, updated_at)
+        VALUES ($1, $2, $3, NOW())
+        ON CONFLICT (user_id, expo_push_token) DO UPDATE
+        SET platform = EXCLUDED.platform,
+            updated_at = NOW()
+        "#,
+    )
+    .bind(user_id)
+    .bind(token)
+    .bind(platform)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn period_yield_matches_linear_formula() {
+        let earned = estimate_period_yield(2_000_000, 500, 86_400);
+        let expected = 2_000_000 * 500 * 86_400 / (10_000 * SECONDS_PER_YEAR);
+        assert_eq!(earned, expected);
+    }
+}

--- a/backend/src/services/sweep_worker.rs
+++ b/backend/src/services/sweep_worker.rs
@@ -1,0 +1,97 @@
+use sqlx::PgPool;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::db::r#yield::{list_auto_sweep_candidates, process_internal_sweep_deposit};
+
+const DEFAULT_SWEEP_INTERVAL_SECS: u64 = 300;
+const DEFAULT_MIN_IDLE_AMOUNT: i64 = 100_000;
+const BATCH_SIZE: i64 = 50;
+
+pub struct SweepWorkerConfig {
+    pub poll_interval: Duration,
+    pub min_idle_amount: i64,
+}
+
+impl SweepWorkerConfig {
+    pub fn from_env() -> Self {
+        let poll_secs = std::env::var("SWEEP_POLL_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_SWEEP_INTERVAL_SECS);
+        let min_idle = std::env::var("SWEEP_MIN_IDLE_AMOUNT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_MIN_IDLE_AMOUNT);
+
+        Self {
+            poll_interval: Duration::from_secs(poll_secs),
+            min_idle_amount: min_idle,
+        }
+    }
+}
+
+/// BE-029: Periodically sweep idle available stablecoin balances into the
+/// yield vault for users with auto-earn enabled.
+pub async fn run(pool: PgPool, config: SweepWorkerConfig) {
+    tracing::info!(
+        "Starting auto-sweep worker (interval={:?}, min_idle={})",
+        config.poll_interval,
+        config.min_idle_amount
+    );
+
+    let mut interval = tokio::time::interval(config.poll_interval);
+
+    loop {
+        interval.tick().await;
+
+        if let Err(err) = sweep_once(&pool, config.min_idle_amount).await {
+            tracing::error!("Auto-sweep cycle failed: {err:?}");
+        }
+    }
+}
+
+async fn sweep_once(pool: &PgPool, min_idle_amount: i64) -> Result<(), sqlx::Error> {
+    let candidates = list_auto_sweep_candidates(pool, min_idle_amount, BATCH_SIZE).await?;
+
+    if candidates.is_empty() {
+        tracing::debug!("Auto-sweep: no eligible users this cycle");
+        return Ok(());
+    }
+
+    let mut swept = 0usize;
+    for balance in candidates {
+        let amount = balance.available_balance;
+        if amount < min_idle_amount {
+            continue;
+        }
+
+        let tx_hash = format!("zaps-auto-sweep-{}", Uuid::new_v4());
+        match process_internal_sweep_deposit(pool, balance.user_id, amount, &tx_hash).await {
+            Ok(()) => {
+                swept += 1;
+                tracing::info!(
+                    user_id = %balance.user_id,
+                    amount,
+                    "Auto-swept idle balance into yield vault"
+                );
+            }
+            Err(sqlx::Error::RowNotFound) => {
+                tracing::debug!(
+                    user_id = %balance.user_id,
+                    "Auto-sweep skipped: insufficient available balance"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    user_id = %balance.user_id,
+                    error = ?err,
+                    "Auto-sweep deposit failed"
+                );
+            }
+        }
+    }
+
+    tracing::debug!("Auto-sweep cycle complete: swept {} user(s)", swept);
+    Ok(())
+}

--- a/backend/src/services/yield_calc.rs
+++ b/backend/src/services/yield_calc.rs
@@ -1,0 +1,123 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use crate::db::models::UserYieldBalance;
+
+/// Stellar mainnet/testnet approximate ledger cadence (~5 seconds).
+pub const SECONDS_PER_YEAR: i64 = 31_536_000;
+const DEFAULT_APY_BPS: i32 = 500;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct YieldEstimate {
+    /// Interest accrued since the last sync point (micro-units).
+    pub accrued_interest: i64,
+    /// Earning balance including accrued but not yet checkpointed interest.
+    pub total_earning_balance: i64,
+}
+
+/// Linear off-chain yield estimate from the user's earning balance, APY, and
+/// elapsed time since the last blockchain/indexer sync.
+pub fn estimate_accrued_yield(
+    earning_balance: i64,
+    apy_bps: i32,
+    last_sync_at: NaiveDateTime,
+    now: DateTime<Utc>,
+) -> YieldEstimate {
+    if earning_balance <= 0 || apy_bps <= 0 {
+        return YieldEstimate {
+            accrued_interest: 0,
+            total_earning_balance: earning_balance.max(0),
+        };
+    }
+
+    let sync_utc = last_sync_at.and_utc();
+    let elapsed_secs = (now - sync_utc).num_seconds().max(0);
+
+    let accrued = earning_balance
+        .saturating_mul(apy_bps as i64)
+        .saturating_mul(elapsed_secs)
+        / (10_000 * SECONDS_PER_YEAR);
+
+    YieldEstimate {
+        accrued_interest: accrued,
+        total_earning_balance: earning_balance.saturating_add(accrued),
+    }
+}
+
+/// Convenience wrapper for API handlers and background jobs.
+pub fn estimate_for_balance(
+    balance: &UserYieldBalance,
+    apy_bps: Option<i32>,
+    now: DateTime<Utc>,
+) -> YieldEstimate {
+    estimate_accrued_yield(
+        balance.earning_balance,
+        apy_bps.unwrap_or(DEFAULT_APY_BPS),
+        balance.last_yield_sync_at,
+        now,
+    )
+}
+
+/// Helper for feed-style responses that surface live yield totals.
+pub fn format_yield_feed_fields(
+    balance: &UserYieldBalance,
+    apy_bps: Option<i32>,
+) -> (i64, i64, f64) {
+    let estimate = estimate_for_balance(balance, apy_bps, Utc::now());
+    let apy_pct = apy_bps.unwrap_or(DEFAULT_APY_BPS) as f64 / 100.0;
+    (
+        estimate.accrued_interest,
+        estimate.total_earning_balance,
+        apy_pct,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    #[test]
+    fn zero_balance_yields_no_interest() {
+        let sync = NaiveDate::from_ymd_opt(2026, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let est = estimate_accrued_yield(0, 500, sync, now);
+        assert_eq!(est.accrued_interest, 0);
+        assert_eq!(est.total_earning_balance, 0);
+    }
+
+    #[test]
+    fn linear_interest_scales_with_time_and_balance() {
+        let sync = NaiveDate::from_ymd_opt(2026, 6, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-06-02T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        // 1_000_000 micro-units at 5% APY for 1 day
+        let est = estimate_accrued_yield(1_000_000, 500, sync, now);
+        let expected = 1_000_000 * 500 * 86_400 / (10_000 * SECONDS_PER_YEAR);
+        assert_eq!(est.accrued_interest, expected);
+        assert_eq!(est.total_earning_balance, 1_000_000 + expected);
+    }
+
+    #[test]
+    fn negative_elapsed_is_clamped_to_zero() {
+        let sync = NaiveDate::from_ymd_opt(2026, 6, 2)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let est = estimate_accrued_yield(500_000, 500, sync, now);
+        assert_eq!(est.accrued_interest, 0);
+    }
+}


### PR DESCRIPTION
Closes Fracverse/zaps#377
Closes Fracverse/zaps#378
Closes Fracverse/zaps#379
Closes Fracverse/zaps#380

## Summary

Implements backend issues **#377**, **#378**, **#379**, and **#380**:

| Issue | Ticket | Deliverable |
|-------|--------|-------------|
| #377 | BE-029 | Auto-sweep scheduler background worker (`sweep_worker.rs`) |
| #378 | BE-030 | `POST /api/yield/toggle-auto` preference endpoint |
| #379 | BE-031 | Off-chain real-time yield calculator (`yield_calc.rs`) |
| #380 | BE-032 | Daily/weekly yield report notification scheduler (`notifications.rs`) |

### #377 — Auto-sweep scheduler
- Polls users with `auto_earn_enabled = true`
- Sweeps idle `available_balance` into `earning_balance` and logs `DEPOSIT` transactions
- Configurable via `SWEEP_POLL_INTERVAL_SECS` and `SWEEP_MIN_IDLE_AMOUNT`

### #378 — Toggle auto-earn API
- `POST /api/yield/toggle-auto` saves `users.auto_earn_enabled`
- Returns confirmation payload with current `auto_earn_enabled` state
- `GET /api/yield/balance` also exposes `auto_earn_enabled`

### #379 — Off-chain yield calculator
- Linear interest estimate since `last_yield_sync_at` using current APY
- Balance API returns `accrued_interest` and `total_earning_balance`
- `format_yield_feed_fields` helper exposed for feed query responses

### #380 — Yield report notifications
- Daily and weekly schedulers for users with positive earning balances
- Sends Expo push notifications when earned yield exceeds `YIELD_REPORT_THRESHOLD`
- Uses `user_push_tokens` table and Expo Push API

### Database migration
`20260627000000_yield_auto_earn_and_notifications.sql` adds:
- `users.auto_earn_enabled`, `last_daily_yield_report_at`, `last_weekly_yield_report_at`
- `user_yield_balances.last_yield_sync_at`
- `user_push_tokens` table

## Test plan

- [x] `cargo build` succeeds
- [x] Unit tests for `yield_calc` and notification period math pass
- [ ] Run migration and verify `POST /api/yield/toggle-auto` toggles `auto_earn_enabled`
- [ ] Confirm `GET /api/yield/balance` returns live `accrued_interest` / `total_earning_balance`
- [ ] Seed auto-earn user with idle balance; verify sweep worker moves funds
- [ ] Register Expo push token; verify scheduler sends notification above threshold