### PR TITLE
feat: document yield API endpoints in OpenAPI spec (#386)

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -21,6 +21,8 @@ tags:
     description: Likes and comments on payments
   - name: Bridge
     description: Cross-chain token quote, submission, and status tracking
+  - name: Yield
+    description: Yield vault balance, transaction history, deposit, withdraw, and auto-earn toggle
 
 components:
   securitySchemes:
@@ -334,6 +336,176 @@ components:
         confirmations:
           type: integer
           description: Number of confirmations observed on the source chain
+
+    YieldBalanceResponse:
+      type: object
+      required:
+        - available_balance
+        - earning_balance
+        - accrued_interest
+        - total_earning_balance
+        - apy
+        - auto_earn_enabled
+      properties:
+        available_balance:
+          type: integer
+          format: int64
+          description: Idle balance not yet deposited into the vault (micro-units)
+        earning_balance:
+          type: integer
+          format: int64
+          description: Balance currently deposited and earning yield (micro-units)
+        accrued_interest:
+          type: integer
+          format: int64
+          description: Interest accrued since the last on-chain sync (micro-units)
+        total_earning_balance:
+          type: integer
+          format: int64
+          description: earning_balance plus live accrued_interest (micro-units)
+        apy:
+          type: number
+          format: double
+          description: "Current APY as a percentage (e.g. 5.0 for 5%)"
+        auto_earn_enabled:
+          type: boolean
+          description: Whether idle available balance is automatically swept into the vault
+
+    YieldHistoryItem:
+      type: object
+      required:
+        - id
+        - tx_hash
+        - type
+        - amount
+        - created_at
+      properties:
+        id:
+          type: string
+          description: UUID of the yield transaction record
+        tx_hash:
+          type: string
+          description: On-chain or internal reference hash for the operation
+        type:
+          type: string
+          enum:
+            - DEPOSIT
+            - WITHDRAW
+            - INTEREST
+          description: Transaction type
+        amount:
+          type: integer
+          format: int64
+          description: Transaction amount in micro-units
+        created_at:
+          type: string
+          format: date-time
+          description: ISO8601 timestamp of the transaction
+
+    YieldHistoryResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+        - total
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/YieldHistoryItem'
+        limit:
+          type: integer
+          format: int64
+          description: Page size used for this response (1–100)
+        offset:
+          type: integer
+          format: int64
+          description: Number of records skipped
+        total:
+          type: integer
+          format: int64
+          description: Total number of yield transactions for the authenticated user
+
+    DepositRequest:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: Amount to move from available to earning balance (micro-units; must be > 0)
+
+    DepositResponse:
+      type: object
+      required:
+        - available_balance
+        - earning_balance
+        - envelope_xdr
+      properties:
+        available_balance:
+          type: integer
+          format: int64
+          description: Updated available balance after the deposit (micro-units)
+        earning_balance:
+          type: integer
+          format: int64
+          description: Updated earning balance after the deposit (micro-units)
+        envelope_xdr:
+          type: string
+          description: Base64-encoded Stellar XDR transaction envelope for the client wallet to sign and submit
+
+    WithdrawRequest:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: Amount to move from earning to available balance (micro-units; must be > 0). Pass the full earning_balance to withdraw everything.
+
+    WithdrawResponse:
+      type: object
+      required:
+        - available_balance
+        - earning_balance
+        - envelope_xdr
+      properties:
+        available_balance:
+          type: integer
+          format: int64
+          description: Updated available balance after the withdrawal (micro-units)
+        earning_balance:
+          type: integer
+          format: int64
+          description: Updated earning balance after the withdrawal (micro-units)
+        envelope_xdr:
+          type: string
+          description: Base64-encoded Stellar XDR transaction envelope for the client wallet to sign and submit
+
+    ToggleAutoEarnRequest:
+      type: object
+      required:
+        - enabled
+      properties:
+        enabled:
+          type: boolean
+          description: Set to true to enable automatic sweep of idle balance into the yield vault
+
+    ToggleAutoEarnResponse:
+      type: object
+      required:
+        - auto_earn_enabled
+        - message
+      properties:
+        auto_earn_enabled:
+          type: boolean
+          description: The updated auto-earn preference that was persisted
+        message:
+          type: string
+          description: Human-readable confirmation of the new setting
 
 paths:
   /health:
@@ -909,6 +1081,246 @@ paths:
                 $ref: '#/components/schemas/BridgeStatusResponse'
         '404':
           description: Bridge transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/yield/balance:
+    get:
+      tags:
+        - Yield
+      summary: Get yield vault balance for the authenticated user
+      operationId: getYieldBalance
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Current yield balance and live accrued interest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/YieldBalanceResponse'
+              example:
+                available_balance: 1000000
+                earning_balance: 5000000
+                accrued_interest: 1234
+                total_earning_balance: 5001234
+                apy: 5.0
+                auto_earn_enabled: true
+        '401':
+          description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Missing authorization header
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Failed to retrieve yield balance
+
+  /api/yield/history:
+    get:
+      tags:
+        - Yield
+      summary: Get paginated yield transaction history for the authenticated user
+      operationId: getYieldHistory
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: "Number of records to return (1–100, default: 20)"
+          schema:
+            type: integer
+            format: int64
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          required: false
+          description: "Number of records to skip (default: 0)"
+          schema:
+            type: integer
+            format: int64
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: Paginated list of yield transactions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/YieldHistoryResponse'
+              example:
+                items:
+                  - id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                    tx_hash: "zaps-yield-deposit-3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                    type: DEPOSIT
+                    amount: 5000000
+                    created_at: "2026-06-27T10:00:00Z"
+                limit: 20
+                offset: 0
+                total: 1
+        '401':
+          description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/yield/deposit:
+    post:
+      tags:
+        - Yield
+      summary: Deposit from available balance into the yield vault
+      operationId: yieldDeposit
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DepositRequest'
+            example:
+              amount: 5000000
+      responses:
+        '200':
+          description: Deposit processed; updated balances and Stellar XDR envelope returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DepositResponse'
+        '400':
+          description: Amount is zero or negative, or insufficient available balance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                non_positive:
+                  summary: Non-positive amount
+                  value:
+                    error: Amount must be greater than zero
+                insufficient:
+                  summary: Insufficient available balance
+                  value:
+                    error: Insufficient available balance
+                    available: 1000000
+        '401':
+          description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/yield/withdraw:
+    post:
+      tags:
+        - Yield
+      summary: Withdraw from the yield vault back to available balance
+      operationId: yieldWithdraw
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WithdrawRequest'
+            example:
+              amount: 2000000
+      responses:
+        '200':
+          description: Withdrawal processed; updated balances and Stellar XDR envelope returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WithdrawResponse'
+        '400':
+          description: Amount is zero or negative, or insufficient earning balance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                non_positive:
+                  summary: Non-positive amount
+                  value:
+                    error: Amount must be greater than zero
+                insufficient:
+                  summary: Insufficient earning balance
+                  value:
+                    error: Insufficient earning balance
+                    earning: 1000000
+        '401':
+          description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/yield/toggle-auto:
+    post:
+      tags:
+        - Yield
+      summary: Enable or disable automatic sweeping of idle balance into the yield vault
+      operationId: toggleAutoEarn
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToggleAutoEarnRequest'
+            example:
+              enabled: true
+      responses:
+        '200':
+          description: Auto-earn preference updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToggleAutoEarnResponse'
+              example:
+                auto_earn_enabled: true
+                message: "Auto-earn enabled. Idle stablecoins will be swept into the yield vault."
+        '401':
+          description: Missing or invalid JWT
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

- Add `Yield` tag and 9 new schemas to `backend/docs/openapi.yaml` covering balance, history, deposit, withdraw, and auto-earn toggle
- Document all 5 yield endpoints (`GET /api/yield/balance`, `GET /api/yield/history`, `POST /api/yield/deposit`, `POST /api/yield/withdraw`, `POST /api/yield/toggle-auto`) with request bodies, query params, response schemas, and error cases
- All endpoints are secured with `BearerAuth`

## Test plan

- [x] YAML parses without errors (`python3 -c "import yaml; yaml.safe_load(open('backend/docs/openapi.yaml'))"`)
- [x] Import into Swagger UI / Redoc and confirm all 5 yield paths render correctly
- [x] Verify request/response field names match the Rust structs in `backend/src/api/yield.rs`
- [x] CI backend job passes (only Rust checks; no YAML linter in pipeline)

Closes #386
