### PR TITLE
#448 [SC-044] SocialGraph: O(1) Gas storage optimization FIXED

### DIFF
--- a/contracts/contracts/social_graph/src/lib.rs
+++ b/contracts/contracts/social_graph/src/lib.rs
@@ -1,10 +1,18 @@
 #![no_std]
 #![allow(unexpected_cfgs)]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
 #[contracttype]
+#[derive(Clone)]
 enum DataKey {
-    Friends(Address),
+    Friendship(Address, Address),
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FriendshipStatus {
+    Active,
+    Removed,
 }
 
 #[contract]
@@ -12,57 +20,87 @@ pub struct SocialGraphContract;
 
 #[contractimpl]
 impl SocialGraphContract {
-    /// Add a friend relationship on-chain (stored as persistent vec per user)
+    /// Add a directed friend relationship on-chain.
+    ///
+    /// Each friendship is stored independently under the composite key
+    /// `(user, friend)`, avoiding loading or rewriting a per-user vector of
+    /// addresses as the user's social graph grows.
     pub fn add_friend(env: Env, user: Address, friend: Address) {
         user.require_auth();
         assert!(user != friend, "cannot friend yourself");
-        let key = DataKey::Friends(user.clone());
-        let mut friends: Vec<Address> = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(&env));
-        if !friends.contains(&friend) {
-            friends.push_back(friend);
-            env.storage().persistent().set(&key, &friends);
-        }
-    }
 
-    /// Remove a friend relationship on-chain
-    pub fn remove_friend(env: Env, user: Address, friend: Address) {
-        user.require_auth();
-        let key = DataKey::Friends(user.clone());
-        let friends: Vec<Address> = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(&env));
-        let mut updated: Vec<Address> = Vec::new(&env);
-        for f in friends.iter() {
-            if f != friend {
-                updated.push_back(f);
-            }
-        }
-        env.storage().persistent().set(&key, &updated);
-    }
-
-    /// Check if two addresses are friends on-chain
-    pub fn is_friend(env: Env, user: Address, friend: Address) -> bool {
-        let key = DataKey::Friends(user);
-        let friends: Vec<Address> = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(&env));
-        friends.contains(&friend)
-    }
-
-    /// Get the friends list for a user
-    pub fn get_friends(env: Env, user: Address) -> Vec<Address> {
-        let key = DataKey::Friends(user);
+        let key = DataKey::Friendship(user, friend);
         env.storage()
             .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(&env))
+            .set(&key, &FriendshipStatus::Active);
     }
+
+    /// Remove a directed friend relationship on-chain.
+    pub fn remove_friend(env: Env, user: Address, friend: Address) {
+        user.require_auth();
+
+        let key = DataKey::Friendship(user, friend);
+        env.storage()
+            .persistent()
+            .set(&key, &FriendshipStatus::Removed);
+    }
+
+    /// Check if two addresses are friends on-chain.
+    pub fn is_friend(env: Env, user: Address, friend: Address) -> bool {
+        let key = DataKey::Friendship(user, friend);
+        let status: Option<FriendshipStatus> = env.storage().persistent().get(&key);
+
+        status == Some(FriendshipStatus::Active)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn setup() -> (
+        Env,
+        SocialGraphContractClient<'static>,
+        Address,
+        Address,
+        Address,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, SocialGraphContract);
+        let client = SocialGraphContractClient::new(&env, &contract_id);
+        let user = Address::generate(&env);
+        let friend = Address::generate(&env);
+        let other = Address::generate(&env);
+
+        (env, client, user, friend, other)
+    }
+
+    #[test]
+    fn add_friend_stores_independent_composite_friendship() {
+        let (_env, client, user, friend, other) = setup();
+
+        assert!(!client.is_friend(&user, &friend));
+        assert!(!client.is_friend(&user, &other));
+
+        client.add_friend(&user, &friend);
+
+        assert!(client.is_friend(&user, &friend));
+        assert!(!client.is_friend(&user, &other));
+        assert!(!client.is_friend(&friend, &user));
+    }
+
+    #[test]
+    fn remove_friend_marks_composite_friendship_removed() {
+        let (_env, client, user, friend, _other) = setup();
+
+        client.add_friend(&user, &friend);
+        assert!(client.is_friend(&user, &friend));
+
+        client.remove_friend(&user, &friend);
+        assert!(!client.is_friend(&user, &friend));
+    }
+
 }


### PR DESCRIPTION
### Findings

The issue was located in:

```text
contracts/contracts/social_graph/src/lib.rs
```

The original implementation stored each user’s friends as a vector:

```rust
enum DataKey {
    Friends(Address),
}
```

That storage model meant each user had one persistent friends list:

```rust
Vec<Address>
```

The contract had to load and process that whole vector in multiple functions.

### Original problem areas

#### `add_friend`

The old code loaded the full friends vector:

```rust
let mut friends: Vec<Address> = env
    .storage()
    .persistent()
    .get(&key)
    .unwrap_or(Vec::new(&env));
```

Then checked if the friend already existed:

```rust
if !friends.contains(&friend) {
    friends.push_back(friend);
    env.storage().persistent().set(&key, &friends);
}
```

Problem:

- Large friend lists require loading the full vector.
- Adding one friend requires rewriting the whole vector.

---

#### `remove_friend`

The old code loaded the full vector:

```rust
let friends: Vec<Address> = env
    .storage()
    .persistent()
    .get(&key)
    .unwrap_or(Vec::new(&env));
```

Then created a new vector without the removed friend:

```rust
let mut updated: Vec<Address> = Vec::new(&env);
for f in friends.iter() {
    if f != friend {
        updated.push_back(f);
    }
}
```

Problem:

- Removing one friend required reading the entire list.
- Removing one friend required rebuilding and rewriting the entire list.

---

#### `is_friend`

The old code also loaded the full vector:

```rust
let friends: Vec<Address> = env
    .storage()
    .persistent()
    .get(&key)
    .unwrap_or(Vec::new(&env));
```

Then checked membership:

```rust
friends.contains(&friend)
```

Problem:

- Checking one friendship required loading a potentially large vector.

---

### Root cause

The root cause was this storage scheme:

```rust
DataKey::Friends(Address) -> Vec<Address>
```

It scaled poorly because one friendship operation depended on the size of the user’s entire friend list.

The issue requested replacing that with:

```rust
(Address, Address) -> status enum
```

---

## Fix features

### 1. Removed per-user `Vec<Address>` storage

Removed:

```rust
use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
```

Replaced with:

```rust
use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
```

No `Vec` is used in the fixed social graph contract.

---

### 2. Replaced per-user storage key with composite friendship key

Before:

```rust
enum DataKey {
    Friends(Address),
}
```

After:

```rust
enum DataKey {
    Friendship(Address, Address),
}
```

Each friendship is now stored independently by the pair:

```text
(user, friend)
```

---

### 3. Added friendship status enum

Added:

```rust
#[contracttype]
#[derive(Clone, Copy, Debug, Eq, PartialEq)]
pub enum FriendshipStatus {
    Active,
    Removed,
}
```

This gives each composite friendship key an explicit state.

Storage now works like:

```text
DataKey::Friendship(user, friend) -> FriendshipStatus::Active
```

or:

```text
DataKey::Friendship(user, friend) -> FriendshipStatus::Removed
```

---

### 4. Updated `add_friend`

Before, `add_friend` loaded the full vector, checked membership, pushed the friend, and rewrote the vector.

Now it writes only one key:

```rust
pub fn add_friend(env: Env, user: Address, friend: Address) {
    user.require_auth();
    assert!(user != friend, "cannot friend yourself");

    let key = DataKey::Friendship(user, friend);
    env.storage()
        .persistent()
        .set(&key, &FriendshipStatus::Active);
}
```

Benefit:

- Constant-size storage operation.
- No full friends list is loaded.
- No vector rewrite is needed.
- Re-adding a removed friend simply sets the status back to `Active`.

---

### 5. Updated `remove_friend`

Before, `remove_friend` loaded the full vector and rebuilt it without the removed friend.

Now it updates only one key:

```rust
pub fn remove_friend(env: Env, user: Address, friend: Address) {
    user.require_auth();

    let key = DataKey::Friendship(user, friend);
    env.storage()
        .persistent()
        .set(&key, &FriendshipStatus::Removed);
}
```

Benefit:

- No large vector is loaded.
- No vector is rebuilt.
- Only the specific friendship pair is updated.

---

### 6. Updated `is_friend`

Before, `is_friend` loaded the entire friends vector and called `contains`.

Now it reads only one composite key:

```rust
pub fn is_friend(env: Env, user: Address, friend: Address) -> bool {
    let key = DataKey::Friendship(user, friend);
    let status: Option<FriendshipStatus> = env.storage().persistent().get(&key);

    status == Some(FriendshipStatus::Active)
}
```

Benefit:

- Checking friendship no longer depends on the size of the user’s friend list.
- Missing key means not friends.
- `Removed` status means not friends.
- `Active` status means friends.

---

### 7. Removed `get_friends`

The old function was:

```rust
pub fn get_friends(env: Env, user: Address) -> Vec<Address>
```

It returned the full vector of friends.

This was removed because the issue specifically required:

```text
Remove Vec storage per user.
Store each friendship independently using a composite key.
```

Returning a full friends list from on-chain storage would require maintaining a per-user list/index, which would conflict with the storage change requested in the issue.

---

### 8. Added tests

Added tests inside:

```text
contracts/contracts/social_graph/src/lib.rs
```

Tests verify:

#### Adding a friendship

```rust
add_friend_stores_independent_composite_friendship
```

Confirms:

- friendship is false before adding
- friendship is true after adding
- unrelated friendships are unaffected
- friendship direction is respected

#### Removing a friendship

```rust
remove_friend_marks_composite_friendship_removed
```

Confirms:

- friendship is active after adding
- friendship is inactive after removal

---

## Conclusion

The fix changes the social graph contract from a per-user vector model to independent composite-key friendship records.

Final storage model:

```rust
DataKey::Friendship(Address, Address) -> FriendshipStatus
```

This directly resolves the issue by avoiding large vector loads and rewrites for friendship operations.

CLOSE #448 