### PR TITLE
Prevent rounding division errors where small transactions result in z…

### DIFF
--- a/contracts/contracts/social_payment/src/lib.rs
+++ b/contracts/contracts/social_payment/src/lib.rs
@@ -95,6 +95,7 @@ impl SocialPaymentContract {
                 .get(&FEE_COEFF_KEY)
                 .unwrap_or(10u32);
             let fee = amount * (fee_coef as i128) / 10000;
+            let fee = if fee == 0 { 1 } else { fee };
             let receiver_amount = amount - fee;
             token_client.transfer(&sender, &receiver, &receiver_amount);
             if fee > 0 {


### PR DESCRIPTION
## Description

Prevent rounding division errors where small public transfer amounts result in zero platform fees.

## Change

Added a minimum-fee floor in `pay()` so that any positive public transfer amount incurs at least 1 stroop in platform fees, even when `amount * fee_coef / 10000` rounds to zero.

## Files Changed

- `contracts/contracts/social_payment/src/lib.rs` — one-line clamp: `let fee = if fee == 0 { 1 } else { fee }`

## Testing

All 6 tests pass (3 ignored as before).


closes #440