### PR TITLE
fix #436: optimize registry storage using individual keys

### DIFF
--- a/contracts/contracts/user_registry/src/lib.rs
+++ b/contracts/contracts/user_registry/src/lib.rs
@@ -5,14 +5,12 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map, Strin
 #[contract]
 pub struct UserRegistryContract;
 
-// Storage keys for persistent storage
-const ADDRESS_TO_USERNAME: &str = "address_to_username";
-const USERNAME_TO_ADDRESS: &str = "username_to_address";
-
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
-    Avatar(Address),
+    User(Address),     // Maps Address -> Username (String)
+    Username(String),  // Maps Username (String) -> Address
+    Avatar(Address),   // Maps Address -> Avatar URI (String)
 }
 
 #[contractimpl]
@@ -22,68 +20,34 @@ impl UserRegistryContract {
         // TODO: Implement SC-002 (Validate username rules: length 3-15, alphanumeric, lowercase)
         user.require_auth();
 
-        // Convert storage keys to Soroban String
-        let address_key = String::from_str(&env, ADDRESS_TO_USERNAME);
-        let username_key = String::from_str(&env, USERNAME_TO_ADDRESS);
-
-        // Get storage instances
-        let address_to_username: Map<Address, String> = env
-            .storage()
-            .persistent()
-            .get(&address_key)
-            .unwrap_or(Map::new(&env));
-        let username_to_address: Map<String, Address> = env
-            .storage()
-            .persistent()
-            .get(&username_key)
-            .unwrap_or(Map::new(&env));
+        let username_key = DataKey::Username(username.clone());
+        let user_key = DataKey::User(user.clone());
 
         // Check if username is already taken (uniqueness validation)
-        if username_to_address.contains_key(username.clone()) {
+        if env.storage().persistent().has(&username_key) {
             panic!("username already taken");
         }
 
         // Store the mappings
-        let mut address_to_username = address_to_username;
-        let mut username_to_address = username_to_address;
-
-        address_to_username.set(user.clone(), username.clone());
-        username_to_address.set(username, user);
-
-        // Persist to storage
-        env.storage()
-            .persistent()
-            .set(&address_key, &address_to_username);
-        env.storage()
-            .persistent()
-            .set(&username_key, &username_to_address);
+        env.storage().persistent().set(&user_key, &username);
+        env.storage().persistent().set(&username_key, &user);
     }
 
     /// Retrieve the Address associated with a username
     pub fn get_address(env: Env, username: String) -> Address {
-        let username_key = String::from_str(&env, USERNAME_TO_ADDRESS);
-        let username_to_address: Map<String, Address> = env
-            .storage()
+        let username_key = DataKey::Username(username);
+        env.storage()
             .persistent()
             .get(&username_key)
-            .unwrap_or(Map::new(&env));
-
-        username_to_address
-            .get(username)
             .unwrap_or_else(|| panic!("username not found"))
     }
 
     /// Retrieve the username associated with an Address
     pub fn get_username(env: Env, user: Address) -> String {
-        let address_key = String::from_str(&env, ADDRESS_TO_USERNAME);
-        let address_to_username: Map<Address, String> = env
-            .storage()
+        let user_key = DataKey::User(user);
+        env.storage()
             .persistent()
-            .get(&address_key)
-            .unwrap_or(Map::new(&env));
-
-        address_to_username
-            .get(user)
+            .get(&user_key)
             .unwrap_or_else(|| panic!("address not registered"))
     }
 


### PR DESCRIPTION
Closes #436 


## PR Description
This PR addresses optimizies the storage usage in the `user_registry` Soroban smart contract. 

Previously, the contract stored two monolithic maps in persistent storage:
1. `address_to_username`: `Map<Address, String>`
2. `username_to_address`: `Map<String, Address>`

As the number of registered users grows, this map-based pattern scales poorly ($O(N)$ gas fees for serialization/deserialization on every write and read) and runs the risk of exceeding the Soroban ledger entry size limit (typically 64KB).

### How the Flow Works Now
We have replaced the maps with a **Variable DataKey** pattern. The `DataKey` enum now includes individual composite keys:
* `DataKey::User(Address)`: Maps a user's `Address` to their registered `String` username.
* `DataKey::Username(String)`: Maps a `String` username to the user's `Address`.

During registration, we check if the username is taken by querying the existence of the individual `DataKey::Username` key in persistent storage. If it is available, we write two small, independent ledger entries. Retrieving a username or address is now a direct, constant-time ($O(1)$) lookup on these keys.

## Changed
* **Smart Contracts (`contracts/contracts/user_registry/src/lib.rs`)**:
  * Added `User(Address)` and `Username(String)` variants to `DataKey` enum to resolve #436 (`[SC-032]`).
  * Removed `ADDRESS_TO_USERNAME` and `USERNAME_TO_ADDRESS` string constants.
  * Refactored `register_user`, `get_address`, and `get_username` to read and write individual keys via `env.storage().persistent()`.

## Testing
The following automated verification commands were executed successfully:
1. **Unit Tests**:
   ```bash
   cargo test -p zaps-user-registry
   ```
2. **Production WASM Compilation**:
   ```bash
   cargo build --target wasm32-unknown-unknown --release -p zaps-user-registry
   ```