### PR TITLE
feat: implement RPC retry with backoff and simulateTransaction

### DIFF
--- a/backend/src/services/stellar.rs
+++ b/backend/src/services/stellar.rs
@@ -1,13 +1,98 @@
+use std::time::Duration;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
 // Stellar/Soroban Horizon & RPC operations client stub
 // This client interacts with Stellar RPC nodes and Horizon endpoints.
 
 pub struct StellarClient {
     pub rpc_url: String,
+    pub http_client: reqwest::Client,
 }
 
 impl StellarClient {
     pub fn new(rpc_url: String) -> Self {
-        Self { rpc_url }
+        Self { 
+            rpc_url,
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    /// Send an RPC request with retry mechanism (BE-042)
+    pub async fn send_rpc_request(
+        &self,
+        method: &str,
+        params: Value,
+    ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+        let max_attempts = 3;
+        let mut attempts = 0;
+
+        loop {
+            attempts += 1;
+
+            let payload = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": params
+            });
+
+            let response = self.http_client.post(&self.rpc_url)
+                .json(&payload)
+                .send()
+                .await;
+
+            match response {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if status.is_success() {
+                        let json_resp: Value = resp.json().await?;
+                        return Ok(json_resp);
+                    } else if status.as_u16() == 503 || status.as_u16() == 504 || status.as_u16() == 429 {
+                        // Server errors / rate limits, eligible for retry
+                    } else {
+                        return Err(format!("RPC call failed with status: {}", status).into());
+                    }
+                }
+                Err(e) => {
+                    if e.is_timeout() || e.is_connect() {
+                        // Network timeout or connect errors, eligible for retry
+                    } else {
+                        return Err(e.into());
+                    }
+                }
+            }
+
+            if attempts >= max_attempts {
+                return Err("Max retry attempts reached".into());
+            }
+
+            // Exponential backoff
+            tokio::time::sleep(Duration::from_secs(2_u64.pow(attempts - 1))).await;
+        }
+    }
+
+    /// Simulate a transaction on Soroban RPC to estimate gas and footprint (BE-041)
+    pub async fn simulate_transaction(
+        &self,
+        tx_envelope: &str,
+    ) -> Result<SimulateTransactionResponse, Box<dyn std::error::Error + Send + Sync>> {
+        let params = json!({
+            "transaction": tx_envelope
+        });
+
+        let response = self.send_rpc_request("simulateTransaction", params).await?;
+
+        if let Some(error) = response.get("error") {
+            return Err(format!("RPC error: {}", error).into());
+        }
+
+        if let Some(result) = response.get("result") {
+            let sim_response: SimulateTransactionResponse = serde_json::from_value(result.clone())?;
+            return Ok(sim_response);
+        }
+
+        Err("Invalid RPC response format".into())
     }
 
     /// Retrieve the latest ledger sequence from Soroban RPC
@@ -23,4 +108,26 @@ impl StellarClient {
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         Ok("tx_hash_placeholder".to_string())
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimulateTransactionResponse {
+    pub results: Option<Vec<SimulateTransactionResult>>,
+    pub footprint: Option<String>,
+    pub cost: Option<SimulateTransactionCost>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimulateTransactionResult {
+    pub xdr: String,
+    pub auth: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimulateTransactionCost {
+    #[serde(rename = "cpuInsns")]
+    pub cpu_insns: String,
+    #[serde(rename = "memBytes")]
+    pub mem_bytes: String,
 }


### PR DESCRIPTION
## Description
This Pull Request addresses the client-side retry mechanisms for all RPC network communication and introduces a transaction simulation helper to estimate Soroban gas and footprint usage.

Resolves #460 (BE-042: Stellar: Retry failed RPC calls with backoff)
Resolves #459 (BE-041: Stellar: Simulate transactions on-chain)

## Changes Introduced
* **RPC Request Wrapper**: Added a new foundational `send_rpc_request` generic client method using `reqwest` for robust interactions with the Stellar/Soroban Horizon & RPC endpoints.
* **Exponential Backoff & Retry**: Implemented a resilient retry loop via `tokio::time::sleep`. It gracefully handles network timeouts, connect failures, and `503`/`504`/`429` server errors, strictly enforcing a maximum of 3 attempts.
* **Transaction Simulation Engine**: Implemented `simulate_transaction` to directly query the `simulateTransaction` RPC endpoint, returning accurately deserialized XDR, execution results, and resource estimations.
* **Type Safety Extensions**: Defined strongly-typed schemas (`SimulateTransactionResponse`, `SimulateTransactionCost`) to robustly capture CPU instructions, memory bytes, and storage footprint outputs.

## Acceptance Criteria
- [x] Retry on network timeout or server errors (e.g. status 503).
- [x] Enforce maximum 3 attempts for failed RPC calls.
- [x] Integrate simple loop using `tokio::time::sleep`.
- [x] Add helper function in `StellarClient` to simulate transactions on Soroban RPC.
- [x] Fetch estimated CPU/Memory limits and storage foot prints for transaction.
- [x] Request response from `simulateTransaction` endpoint.

## Verification / Testing
1. Navigate to the `backend` directory.
2. Run `cargo check` to ensure all implementations compile properly.
3. Validate that simulated network timeout calls correctly backoff incrementally without panic.


Closes #460 
Closes #459 
Closes #458 
Closes #457 