### PR TITLE
Reject deposit/withdraw amounts with invalid decimal precision

### DIFF
--- a/backend/src/api/yield.rs
+++ b/backend/src/api/yield.rs
@@ -7,11 +7,39 @@ use axum::{
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use sqlx::Row;
 use uuid::Uuid;
 
 use crate::services::yield_calc;
+
+// ── Decimal precision validation ──────────────────────────────────────────
+//
+// Naira token amounts are integers expressed in micro-units (the smallest
+// indivisible denomination of the token). Fractional micro-units are
+// meaningless — e.g. 1000.5 cannot be represented on-chain.
+//
+// This deserializer accepts any JSON number but rejects it if it carries a
+// fractional part (i.e. it is not a whole number), returning a clear error
+// message rather than silently truncating or failing with a type error.
+
+fn deserialize_whole_number<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Deserialize as f64 first so we can inspect the fractional part.
+    let raw = f64::deserialize(deserializer)?;
+    if raw.fract() != 0.0 {
+        return Err(serde::de::Error::custom(
+            "amount must be a whole number — fractional micro-units are not supported by the Naira token",
+        ));
+    }
+    // Check that the value fits in i64 without loss.
+    if raw < i64::MIN as f64 || raw > i64::MAX as f64 {
+        return Err(serde::de::Error::custom("amount is out of range for i64"));
+    }
+    Ok(raw as i64)
+}
 
 // ── #373 — GET /api/yield/balance ─────────────────────────────────────────
 
@@ -226,6 +254,8 @@ pub async fn toggle_auto_earn(
 #[derive(Deserialize)]
 pub struct DepositRequest {
     /// Amount to move from available to earning balance (in micro-units).
+    /// Must be a whole number; fractional micro-units are rejected.
+    #[serde(deserialize_with = "deserialize_whole_number")]
     pub amount: i64,
 }
 
@@ -371,6 +401,8 @@ pub async fn deposit(
 pub struct WithdrawRequest {
     /// Amount to move from earning to available balance (in micro-units).
     /// Pass the full earning balance to withdraw everything.
+    /// Must be a whole number; fractional micro-units are rejected.
+    #[serde(deserialize_with = "deserialize_whole_number")]
     pub amount: i64,
 }
 

--- a/backend/tests/yield_api_tests.rs
+++ b/backend/tests/yield_api_tests.rs
@@ -284,3 +284,176 @@ async fn test_yield_balance_history_toggle() {
     let _ = AuthUser;
 }
 
+// ── Decimal precision validation tests ───────────────────────────────────────
+//
+// Naira token amounts are integers in micro-units. Any fractional value is
+// meaningless on-chain and must be rejected with HTTP 422 Unprocessable Entity
+// (Axum returns 422 when JSON deserialization fails).
+
+#[tokio::test]
+async fn test_deposit_rejects_fractional_amount() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GTESTPRECDEPOSIT{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    // 1000.5 — fractional micro-unit — must be rejected.
+    let (status, body) = response_json(
+        &router,
+        post_req_json(
+            "/deposit",
+            Some(&token),
+            serde_json::json!({ "amount": 1000.5_f64 }),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "deposit with fractional amount must return 422, body: {:?}",
+        body
+    );
+
+    // 0.1 — also fractional
+    let (status2, body2) = response_json(
+        &router,
+        post_req_json(
+            "/deposit",
+            Some(&token),
+            serde_json::json!({ "amount": 0.1_f64 }),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        status2,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "deposit with 0.1 must return 422, body: {:?}",
+        body2
+    );
+
+    // A whole-number float (1000.0) must be accepted by the deserializer itself
+    // (may still fail with 400 for insufficient balance, but not 422).
+    let (status3, _body3) = response_json(
+        &router,
+        post_req_json(
+            "/deposit",
+            Some(&token),
+            serde_json::json!({ "amount": 1000.0_f64 }),
+        ),
+    )
+    .await;
+    assert_ne!(
+        status3,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "deposit with whole-number float 1000.0 must not return 422"
+    );
+
+    // Cleanup.
+    sqlx::query("DELETE FROM yield_transactions WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM user_yield_balances WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+async fn test_withdraw_rejects_fractional_amount() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GTESTPRECWITHDRAW{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    // 500.99 — fractional micro-unit — must be rejected.
+    let (status, body) = response_json(
+        &router,
+        post_req_json(
+            "/withdraw",
+            Some(&token),
+            serde_json::json!({ "amount": 500.99_f64 }),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "withdraw with fractional amount must return 422, body: {:?}",
+        body
+    );
+
+    // 1.1 — also fractional.
+    let (status2, body2) = response_json(
+        &router,
+        post_req_json(
+            "/withdraw",
+            Some(&token),
+            serde_json::json!({ "amount": 1.1_f64 }),
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        status2,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "withdraw with 1.1 must return 422, body: {:?}",
+        body2
+    );
+
+    // A whole-number float (500.0) must pass the precision check.
+    let (status3, _body3) = response_json(
+        &router,
+        post_req_json(
+            "/withdraw",
+            Some(&token),
+            serde_json::json!({ "amount": 500.0_f64 }),
+        ),
+    )
+    .await;
+    assert_ne!(
+        status3,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "withdraw with whole-number float 500.0 must not return 422"
+    );
+
+    // Cleanup.
+    sqlx::query("DELETE FROM yield_transactions WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM user_yield_balances WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+


### PR DESCRIPTION
 Reject deposit/withdrawal amounts with invalid decimal precision
  
  Naira token amounts are stored and processed as integer micro-units — the
  smallest indivisible denomination on-chain. Fractional values like 1000.5 are
  meaningless at the contract level and were previously either silently truncated
  by serde or surfaced as an unhelpful type error.
  
  Changes
  
  - Added a deserialize_whole_number custom serde deserializer in
  backend/src/api/yield.rs that accepts any JSON number but rejects it with a
  clear domain-specific error if it has a fractional part (checked via
  f64::fract() != 0.0)
  - Applied the deserializer to DepositRequest.amount and WithdrawRequest.amount
   — Axum returns HTTP 422 Unprocessable Entity on failure
  - Added integration tests in backend/tests/yield_api_tests.rs covering:
    - 1000.5, 0.1 → 422 on deposit
    - 500.99, 1.1 → 422 on withdraw
    - 1000.0, 500.0 (whole-number floats) → pass precision check
  
  Testing
  
  Existing yield endpoint tests remain unchanged and continue to cover balance,
  history, toggle-auto, deposit, and withdraw flows.

closes #478
