### PR TITLE
feat: emit FriendAdded and FriendRemoved events

### DIFF
--- a/contracts/contracts/social_graph/src/lib.rs
+++ b/contracts/contracts/social_graph/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![allow(unexpected_cfgs)]
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
@@ -97,9 +97,17 @@ impl SocialGraphContract {
             &FriendshipStatus::Active,
         );
         env.storage().persistent().set(
-            &DataKey::Friendship(friend, requester),
+            &DataKey::Friendship(friend.clone(), requester.clone()),
             &FriendshipStatus::Active,
         );
+
+        // Emit a `FriendAdded` event so off-chain indexers and
+        // applications can react when a mutual friendship is established.
+        env.events().publish(
+            (Symbol::new(&env, "FriendAdded"),),
+            (requester, friend),
+        );
+
         Ok(())
     }
 
@@ -134,8 +142,15 @@ impl SocialGraphContract {
             &FriendshipStatus::Removed,
         );
         env.storage().persistent().set(
-            &DataKey::Friendship(friend, user),
+            &DataKey::Friendship(friend.clone(), user.clone()),
             &FriendshipStatus::Removed,
+        );
+
+        // Emit a `FriendRemoved` event so off-chain indexers and
+        // applications can react when a mutual friendship is dissolved.
+        env.events().publish(
+            (Symbol::new(&env, "FriendRemoved"),),
+            (user, friend),
         );
     }
 
@@ -160,7 +175,10 @@ impl SocialGraphContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{
+        testutils::{Address as _, Events},
+        Address, Env, IntoVal, Symbol, TryIntoVal, Val,
+    };
 
     fn setup() -> (
         Env,
@@ -195,7 +213,7 @@ mod tests {
 
     #[test]
     fn accept_makes_friendship_mutual() {
-        let (_env, client, user, friend, other) = setup();
+        let (env, client, user, friend, other) = setup();
 
         client.request_friend(&user, &friend);
         client.accept_friend(&friend, &user);
@@ -204,6 +222,21 @@ mod tests {
         assert!(client.is_friend(&friend, &user));
         // Unrelated parties remain unaffected.
         assert!(!client.is_friend(&user, &other));
+
+        // Verify FriendAdded event was emitted with both addresses.
+        let events = env.events().all();
+        let topic_filter: Val = Symbol::new(&env, "FriendAdded").into_val(&env);
+        let mut found = false;
+        for item in events.iter() {
+            if item.1.contains(topic_filter) {
+                let (ev_requester, ev_friend): (Address, Address) =
+                    item.2.try_into_val(&env).unwrap();
+                assert_eq!(ev_requester, user);
+                assert_eq!(ev_friend, friend);
+                found = true;
+            }
+        }
+        assert!(found, "FriendAdded event not emitted");
     }
 
     #[test]
@@ -225,7 +258,7 @@ mod tests {
 
     #[test]
     fn remove_friend_unfriends_both_directions() {
-        let (_env, client, user, friend, _other) = setup();
+        let (env, client, user, friend, _other) = setup();
 
         client.request_friend(&user, &friend);
         client.accept_friend(&friend, &user);
@@ -234,6 +267,21 @@ mod tests {
         client.remove_friend(&user, &friend);
         assert!(!client.is_friend(&user, &friend));
         assert!(!client.is_friend(&friend, &user));
+
+        // Verify FriendRemoved event was emitted with both addresses.
+        let events = env.events().all();
+        let topic_filter: Val = Symbol::new(&env, "FriendRemoved").into_val(&env);
+        let mut found = false;
+        for item in events.iter() {
+            if item.1.contains(topic_filter) {
+                let (ev_user, ev_friend): (Address, Address) =
+                    item.2.try_into_val(&env).unwrap();
+                assert_eq!(ev_user, user);
+                assert_eq!(ev_friend, friend);
+                found = true;
+            }
+        }
+        assert!(found, "FriendRemoved event not emitted");
     }
 
     #[test]

--- a/contracts/contracts/social_graph/test_snapshots/tests/accept_makes_friendship_mutual.1.json
+++ b/contracts/contracts/social_graph/test_snapshots/tests/accept_makes_friendship_mutual.1.json
@@ -385,6 +385,33 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "FriendAdded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {

--- a/contracts/contracts/social_graph/test_snapshots/tests/cannot_request_existing_friend.1.json
+++ b/contracts/contracts/social_graph/test_snapshots/tests/cannot_request_existing_friend.1.json
@@ -383,6 +383,33 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "FriendAdded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {

--- a/contracts/contracts/social_graph/test_snapshots/tests/reject_clears_pending_request.1.json
+++ b/contracts/contracts/social_graph/test_snapshots/tests/reject_clears_pending_request.1.json
@@ -715,6 +715,33 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "FriendAdded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {

--- a/contracts/contracts/social_graph/test_snapshots/tests/remove_friend_unfriends_both_directions.1.json
+++ b/contracts/contracts/social_graph/test_snapshots/tests/remove_friend_unfriends_both_directions.1.json
@@ -440,6 +440,33 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "FriendAdded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -529,6 +556,33 @@
               },
               {
                 "symbol": "remove_friend"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "FriendRemoved"
               }
             ],
             "data": {


### PR DESCRIPTION
## Summary

Add `FriendAdded` and `FriendRemoved` events to the SocialGraph contract so that off‑chain services (indexers, notification bots, analytics) can react to relationship changes in real time, without polling the ledger.

## Motivation

Previously, accepting or removing a friend only updated the internal storage. External systems had no way to detect these changes except by repeatedly scanning the entire friendship graph, which is inefficient and misses real‑time updates.

## Changes

- `accept_friend`
  - Emits a `FriendAdded` event with topics `(Symbol("FriendAdded"),)` and data `(requester, friend)`.
  - Added `.clone()` calls to avoid move conflicts when setting the reverse friendship direction.

- `remove_friend`
  - Emits a `FriendRemoved` event with topics `(Symbol("FriendRemoved"),)` and data `(user, friend)`.
  - Same clone pattern applied for consistency.

- Tests
  - Updated existing tests to assert the new events are emitted with the correct addresses.
  - All 10 contract tests pass without regressions.

- Imports
  - Added `Symbol` to the import list for constructing event topic names.

## Related Issues

Closes #450

## Test Plan

- [x] `cargo test` inside `contracts/contracts/social_graph` passes all 10 tests.
- [x] Manually verified event content:
  - After `accept_friend`, the test environment shows a `FriendAdded` event with `(requester, friend)`.
  - After `remove_friend`, the test environment shows a `FriendRemoved` event with `(user, friend)`.
- [x] Compilation produces no warnings or errors.
- [x] CI checks pass.

## Checklist

- [x] I have read the `CONTRIBUTING.md` guide.
- [x] My code follows the project's style guidelines.
- [x] I have commented my code where necessary.
- [x] No documentation changes required.
- [x] My changes generate no new warnings or errors.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.