### PR TITLE
[BE-062] Yield API: Validation unit tests

### DIFF
--- a/backend/tests/yield_api_tests.rs
+++ b/backend/tests/yield_api_tests.rs
@@ -18,18 +18,28 @@ use sqlx::PgPool;
 use tower::ServiceExt; // for `oneshot`
 use uuid::Uuid;
 
-// Re-exported from crate.
-use zaps_backend::api::feed::AuthUser;
-
 // ── helpers ─────────────────────────────────────────────────────────────────
 
 async fn test_pool() -> PgPool {
     let url = std::env::var("TEST_DATABASE_URL")
         .or_else(|_| std::env::var("DATABASE_URL"))
         .expect("Set TEST_DATABASE_URL or DATABASE_URL to run integration tests");
-    PgPool::connect(&url)
+    let pool = PgPool::connect(&url)
         .await
-        .expect("Failed to connect to test database")
+        .expect("Failed to connect to test database");
+    zaps_backend::db::run_migrations(&pool)
+        .await
+        .expect("Failed to apply test database migrations");
+    pool
+}
+
+/// Builds a syntactically valid, unique Stellar-shaped address for a test
+/// user: `users.address` is `VARCHAR(56)` (see backend/migrations/0001_schema.sql),
+/// so the total length here must be exactly 56 or `seed_user` fails with a
+/// "value too long for type character varying(56)" database error.
+fn test_address(prefix: &str, run: &str) -> String {
+    let padding = 56 - prefix.len() - run.len();
+    format!("{prefix}{run}{}", "X".repeat(padding))
 }
 
 fn yield_router(pool: PgPool) -> Router {
@@ -48,7 +58,10 @@ async fn seed_user(pool: &PgPool, address: &str) -> Uuid {
         "#,
     )
     .bind(address)
-    .bind(format!("user_{}", &address[1..std::cmp::min(10, address.len())]))
+    .bind(format!(
+        "user_{}",
+        &address[1..std::cmp::min(10, address.len())]
+    ))
     .fetch_one(pool)
     .await
     .expect("Failed to seed user")
@@ -109,13 +122,13 @@ async fn test_yield_endpoints_require_auth() {
     let router = yield_router(pool);
 
     // Missing auth header
-    for path in [
-        "/balance",
-        "/history?limit=1&offset=0",
-    ]
-    {
+    for path in ["/balance", "/history?limit=1&offset=0"] {
         let (status, _) = response_json(&router, get_req(path, None)).await;
-        assert_eq!(status, StatusCode::UNAUTHORIZED, "{path} must be 401 without auth");
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "{path} must be 401 without auth"
+        );
     }
 
     // Missing auth header for POST
@@ -126,7 +139,11 @@ async fn test_yield_endpoints_require_auth() {
     ] {
         let req = post_req_json(path, None, payload);
         let (status, _) = response_json(&router, req).await;
-        assert_eq!(status, StatusCode::UNAUTHORIZED, "{path} must be 401 without auth");
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "{path} must be 401 without auth"
+        );
     }
 }
 
@@ -140,10 +157,7 @@ async fn test_yield_balance_history_toggle() {
 
     // This address string is what the AuthUser extractor maps from JWT `sub`.
     // It may not be a real Stellar address; the extractor only uses it as an opaque key.
-    let address = format!(
-        "GTESTYIELDUSER{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GTESTYIELDUSER", &run);
     let user_id = seed_user(&pool, &address).await;
 
     // Token mapping:
@@ -156,15 +170,29 @@ async fn test_yield_balance_history_toggle() {
     assert_eq!(status, StatusCode::OK);
 
     // Validate shape & defaults.
-    assert!(body.get("available_balance").is_some(), "available_balance missing");
-    assert!(body.get("earning_balance").is_some(), "earning_balance missing");
-    assert!(body.get("accrued_interest").is_some(), "accrued_interest missing");
-    assert!(body.get("total_earning_balance").is_some(), "total_earning_balance missing");
+    assert!(
+        body.get("available_balance").is_some(),
+        "available_balance missing"
+    );
+    assert!(
+        body.get("earning_balance").is_some(),
+        "earning_balance missing"
+    );
+    assert!(
+        body.get("accrued_interest").is_some(),
+        "accrued_interest missing"
+    );
+    assert!(
+        body.get("total_earning_balance").is_some(),
+        "total_earning_balance missing"
+    );
     assert!(body.get("apy").is_some(), "apy missing");
 
     // auto_earn_enabled default comes from `users.auto_earn_enabled`.
     assert_eq!(
-        body.get("auto_earn_enabled").and_then(|v| v.as_bool()).unwrap_or(true),
+        body.get("auto_earn_enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
         false,
         "auto_earn_enabled should default to false"
     );
@@ -220,18 +248,18 @@ async fn test_yield_balance_history_toggle() {
     }
 
     // 3) GET /api/yield/history
-    let (hist_status, hist_body) = response_json(
-        &router,
-        get_req("/history?limit=10&offset=0", Some(&token)),
-    )
-    .await;
+    let (hist_status, hist_body) =
+        response_json(&router, get_req("/history?limit=10&offset=0", Some(&token))).await;
     assert_eq!(hist_status, StatusCode::OK);
 
     let items = hist_body
         .get("items")
         .and_then(|v| v.as_array())
         .expect("history items must be array");
-    assert!(!items.is_empty(), "expected at least one yield history item");
+    assert!(
+        !items.is_empty(),
+        "expected at least one yield history item"
+    );
 
     // Validate item fields exist.
     let first = &items[0];
@@ -293,9 +321,6 @@ async fn test_yield_balance_history_toggle() {
         .execute(&pool)
         .await
         .ok();
-
-    // Avoid unused import warning.
-    let _ = AuthUser;
 }
 
 // ── #480 [BE-062] — validation & input-format tests ─────────────────────────
@@ -307,10 +332,7 @@ async fn test_deposit_and_withdraw_reject_non_positive_amount() {
     let router = yield_router(pool.clone());
 
     let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
-    let address = format!(
-        "GVALIDNONPOS{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GVALIDNONPOS", &run);
     let user_id = seed_user(&pool, &address).await;
     let token = address.clone();
 
@@ -351,10 +373,7 @@ async fn test_deposit_rejects_insufficient_available_balance() {
     let router = yield_router(pool.clone());
 
     let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
-    let address = format!(
-        "GVALIDDEPINSUF{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GVALIDDEPINSUF", &run);
     let user_id = seed_user(&pool, &address).await;
     let token = address.clone();
 
@@ -362,7 +381,11 @@ async fn test_deposit_rejects_insufficient_available_balance() {
     // deposit amount must be rejected as insufficient.
     let (status, body) = response_json(
         &router,
-        post_req_json("/deposit", Some(&token), serde_json::json!({ "amount": 100 })),
+        post_req_json(
+            "/deposit",
+            Some(&token),
+            serde_json::json!({ "amount": 100 }),
+        ),
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
@@ -391,10 +414,7 @@ async fn test_withdraw_rejects_insufficient_earning_balance() {
     let router = yield_router(pool.clone());
 
     let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
-    let address = format!(
-        "GVALIDWDINSUF{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GVALIDWDINSUF", &run);
     let user_id = seed_user(&pool, &address).await;
     let token = address.clone();
 
@@ -435,10 +455,7 @@ async fn test_post_endpoints_reject_malformed_json_syntax() {
     let router = yield_router(pool.clone());
 
     let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
-    let address = format!(
-        "GVALIDSYNTAX{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GVALIDSYNTAX", &run);
     let user_id = seed_user(&pool, &address).await;
     let token = address.clone();
 
@@ -475,10 +492,7 @@ async fn test_post_endpoints_reject_invalid_input_shapes() {
     let router = yield_router(pool.clone());
 
     let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
-    let address = format!(
-        "GVALIDSHAPE{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GVALIDSHAPE", &run);
     let user_id = seed_user(&pool, &address).await;
     let token = address.clone();
 
@@ -519,10 +533,7 @@ async fn test_history_clamps_out_of_range_pagination_params() {
     let router = yield_router(pool.clone());
 
     let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
-    let address = format!(
-        "GVALIDCLAMP{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GVALIDCLAMP", &run);
     let user_id = seed_user(&pool, &address).await;
     let token = address.clone();
 
@@ -536,11 +547,8 @@ async fn test_history_clamps_out_of_range_pagination_params() {
     assert_eq!(body.get("limit").and_then(|v| v.as_i64()), Some(100));
 
     // limit of 0 (or negative) is clamped up to the minimum of 1.
-    let (status, body) = response_json(
-        &router,
-        get_req("/history?limit=0&offset=0", Some(&token)),
-    )
-    .await;
+    let (status, body) =
+        response_json(&router, get_req("/history?limit=0&offset=0", Some(&token))).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body.get("limit").and_then(|v| v.as_i64()), Some(1));
 
@@ -568,10 +576,7 @@ async fn test_history_rejects_non_numeric_pagination_params() {
     let router = yield_router(pool.clone());
 
     let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
-    let address = format!(
-        "GVALIDBADQ{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GVALIDBADQ", &run);
     let user_id = seed_user(&pool, &address).await;
     let token = address.clone();
 
@@ -601,10 +606,7 @@ async fn test_toggle_auto_requires_boolean_enabled_field() {
     let router = yield_router(pool.clone());
 
     let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
-    let address = format!(
-        "GVALIDTOGGLE{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        run
-    );
+    let address = test_address("GVALIDTOGGLE", &run);
     let user_id = seed_user(&pool, &address).await;
     let token = address.clone();
 
@@ -632,4 +634,3 @@ async fn test_toggle_auto_requires_boolean_enabled_field() {
         .await
         .ok();
 }
-

--- a/backend/tests/yield_api_tests.rs
+++ b/backend/tests/yield_api_tests.rs
@@ -87,6 +87,20 @@ fn post_req_json(path: &str, token: Option<&str>, payload: Value) -> Request<Bod
         .unwrap()
 }
 
+/// Build a POST request with a raw (possibly malformed) JSON body, so we can
+/// exercise input-format validation that a typed `Value` can't express
+/// (syntax errors, missing fields, wrong field types).
+fn post_req_raw(path: &str, token: Option<&str>, raw_body: &str) -> Request<Body> {
+    let mut builder = Request::builder().method("POST").uri(path);
+    if let Some(t) = token {
+        builder = builder.header("Authorization", format!("Bearer {}", t));
+    }
+    builder
+        .header("content-type", "application/json")
+        .body(Body::from(raw_body.to_string()))
+        .unwrap()
+}
+
 // ── tests ────────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -282,5 +296,340 @@ async fn test_yield_balance_history_toggle() {
 
     // Avoid unused import warning.
     let _ = AuthUser;
+}
+
+// ── #480 [BE-062] — validation & input-format tests ─────────────────────────
+
+/// `amount` must be strictly positive for both /deposit and /withdraw.
+#[tokio::test]
+async fn test_deposit_and_withdraw_reject_non_positive_amount() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GVALIDNONPOS{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    for bad_amount in [0, -1, -1_000_000] {
+        for path in ["/deposit", "/withdraw"] {
+            let (status, body) = response_json(
+                &router,
+                post_req_json(
+                    path,
+                    Some(&token),
+                    serde_json::json!({ "amount": bad_amount }),
+                ),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{path} with amount={bad_amount} must be rejected"
+            );
+            assert!(
+                body.get("error").is_some(),
+                "{path} with amount={bad_amount} must return an error message"
+            );
+        }
+    }
+
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+/// /deposit must reject amounts greater than the user's available balance.
+#[tokio::test]
+async fn test_deposit_rejects_insufficient_available_balance() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GVALIDDEPINSUF{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    // Fresh user's yield balance defaults to 0 available; any positive
+    // deposit amount must be rejected as insufficient.
+    let (status, body) = response_json(
+        &router,
+        post_req_json("/deposit", Some(&token), serde_json::json!({ "amount": 100 })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body.get("error").and_then(|v| v.as_str()),
+        Some("Insufficient available balance")
+    );
+    assert_eq!(body.get("available").and_then(|v| v.as_i64()), Some(0));
+
+    sqlx::query("DELETE FROM user_yield_balances WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+/// /withdraw must reject amounts greater than the user's earning balance.
+#[tokio::test]
+async fn test_withdraw_rejects_insufficient_earning_balance() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GVALIDWDINSUF{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    // Fresh user's yield balance defaults to 0 earning; any positive
+    // withdrawal amount must be rejected as insufficient.
+    let (status, body) = response_json(
+        &router,
+        post_req_json(
+            "/withdraw",
+            Some(&token),
+            serde_json::json!({ "amount": 500 }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body.get("error").and_then(|v| v.as_str()),
+        Some("Insufficient earning balance")
+    );
+    assert_eq!(body.get("earning").and_then(|v| v.as_i64()), Some(0));
+
+    sqlx::query("DELETE FROM user_yield_balances WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+/// Malformed JSON syntax must not be accepted by any POST endpoint.
+#[tokio::test]
+async fn test_post_endpoints_reject_malformed_json_syntax() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GVALIDSYNTAX{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    for (path, raw_body) in [
+        ("/deposit", "{ amount: 1000 "),
+        ("/withdraw", "not-json-at-all"),
+        ("/toggle-auto", "{ \"enabled\": "),
+    ] {
+        let response = router
+            .clone()
+            .oneshot(post_req_raw(path, Some(&token), raw_body))
+            .await
+            .expect("oneshot failed");
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "{path} must reject malformed JSON syntax with 400"
+        );
+    }
+
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+/// Well-formed JSON that is missing required fields, or uses the wrong type
+/// for a field, must be rejected (Axum's `Json` extractor returns 422 for
+/// data errors, as opposed to 400 for syntax errors).
+#[tokio::test]
+async fn test_post_endpoints_reject_invalid_input_shapes() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GVALIDSHAPE{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    for (path, raw_body) in [
+        // Missing required field.
+        ("/deposit", "{}"),
+        ("/withdraw", "{}"),
+        ("/toggle-auto", "{}"),
+        // Wrong field type.
+        ("/deposit", r#"{"amount": "one-thousand"}"#),
+        ("/withdraw", r#"{"amount": null}"#),
+        ("/toggle-auto", r#"{"enabled": "yes"}"#),
+    ] {
+        let response = router
+            .clone()
+            .oneshot(post_req_raw(path, Some(&token), raw_body))
+            .await
+            .expect("oneshot failed");
+        assert_eq!(
+            response.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "{path} with body {raw_body} must reject invalid input shape with 422"
+        );
+    }
+
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+/// /history must clamp out-of-range `limit`/`offset` query params instead of
+/// erroring: limit is clamped to [1, 100], offset is clamped to >= 0.
+#[tokio::test]
+async fn test_history_clamps_out_of_range_pagination_params() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GVALIDCLAMP{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    // limit above the max (100) is clamped down.
+    let (status, body) = response_json(
+        &router,
+        get_req("/history?limit=9999&offset=0", Some(&token)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.get("limit").and_then(|v| v.as_i64()), Some(100));
+
+    // limit of 0 (or negative) is clamped up to the minimum of 1.
+    let (status, body) = response_json(
+        &router,
+        get_req("/history?limit=0&offset=0", Some(&token)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.get("limit").and_then(|v| v.as_i64()), Some(1));
+
+    // Negative offset is clamped up to 0.
+    let (status, body) = response_json(
+        &router,
+        get_req("/history?limit=10&offset=-5", Some(&token)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.get("offset").and_then(|v| v.as_i64()), Some(0));
+
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+/// /history must reject query params that fail to deserialize to the
+/// expected type (e.g. non-numeric `limit`/`offset`).
+#[tokio::test]
+async fn test_history_rejects_non_numeric_pagination_params() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GVALIDBADQ{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    for path in [
+        "/history?limit=not-a-number&offset=0",
+        "/history?limit=10&offset=not-a-number",
+    ] {
+        let (status, _) = response_json(&router, get_req(path, Some(&token))).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{path} must reject non-numeric pagination params with 400"
+        );
+    }
+
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
+}
+
+/// /toggle-auto's `enabled` field is required and must be a boolean.
+#[tokio::test]
+async fn test_toggle_auto_requires_boolean_enabled_field() {
+    let pool = test_pool().await;
+    let router = yield_router(pool.clone());
+
+    let run = Uuid::new_v4().to_string().replace('-', "")[..8].to_string();
+    let address = format!(
+        "GVALIDTOGGLE{}XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        run
+    );
+    let user_id = seed_user(&pool, &address).await;
+    let token = address.clone();
+
+    // Valid boolean values succeed.
+    for enabled in [true, false] {
+        let (status, body) = response_json(
+            &router,
+            post_req_json(
+                "/toggle-auto",
+                Some(&token),
+                serde_json::json!({ "enabled": enabled }),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.get("auto_earn_enabled").and_then(|v| v.as_bool()),
+            Some(enabled)
+        );
+    }
+
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .ok();
 }
 


### PR DESCRIPTION
## Summary
- Adds API integration tests covering input validation for the `/api/yield` endpoints in `backend/tests/yield_api_tests.rs`
- Covers non-positive `amount` rejection on `/deposit` and `/withdraw`
- Covers insufficient available/earning balance rejection on `/deposit` and `/withdraw`
- Covers malformed JSON syntax (400) vs. missing/wrong-typed fields (422) input-format checks across `/deposit`, `/withdraw`, and `/toggle-auto`
- Covers `/history` pagination `limit`/`offset` clamping and rejection of non-numeric query params

Closes #480

## Test plan
- [ ] `cargo test --test yield_api_tests` against a PostgreSQL instance with the Zaps schema applied (`TEST_DATABASE_URL` or `DATABASE_URL` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)