### PR TITLE
Cron scheduling for reports

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -217,6 +217,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +283,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +346,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +396,37 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "digest"
@@ -676,6 +763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1315,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1457,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1823,6 +1951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,7 +2093,7 @@ checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2101,6 +2235,33 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
  "unicode-properties",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2307,6 +2468,22 @@ dependencies = [
  "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-cron-scheduler"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f50e41f200fd8ed426489bd356910ede4f053e30cebfbd59ef0f856f0d7432a"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "croner",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2974,6 +3151,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tokio-cron-scheduler",
  "tower 0.4.13",
  "tower-http",
  "tracing",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,6 +20,7 @@ ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 jsonwebtoken = "9.2.0"
 base64 = "0.22.1"
 hex = "0.4.3"
+tokio-cron-scheduler = "0.15"
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }

--- a/backend/src/indexer/worker.rs
+++ b/backend/src/indexer/worker.rs
@@ -367,9 +367,28 @@ async fn get_or_create_user_id(
     Ok(row.get("id"))
 }
 
+const ADDRESS_SLUG_SKIP_CHARS: usize = 1;
+const ADDRESS_SLUG_TAKE_CHARS: usize = 14;
+const DEFAULT_ADDRESS_SLUG: &str = "u_unknown";
+
+/// Derive a short username slug from a chain address. Bounds are checked in
+/// terms of character counts (not byte offsets) before slicing so malformed
+/// or unexpectedly short/multibyte addresses can never panic; anything too
+/// short to slice falls back to a default placeholder slug.
 fn slugify_address(address: &str) -> String {
     let trimmed = address.trim();
-    let snippet = trimmed.get(1..15).unwrap_or(trimmed);
+    let char_count = trimmed.chars().count();
+
+    if char_count < ADDRESS_SLUG_SKIP_CHARS + ADDRESS_SLUG_TAKE_CHARS {
+        return DEFAULT_ADDRESS_SLUG.to_string();
+    }
+
+    let snippet: String = trimmed
+        .chars()
+        .skip(ADDRESS_SLUG_SKIP_CHARS)
+        .take(ADDRESS_SLUG_TAKE_CHARS)
+        .collect();
+
     format!("u_{}", snippet.to_lowercase())
 }
 
@@ -395,6 +414,37 @@ mod tests {
         assert_eq!(compute_backoff_delay(0), INITIAL_BACKOFF);
         assert_eq!(compute_backoff_delay(1), Duration::from_secs(2));
         assert_eq!(compute_backoff_delay(6), MAX_BACKOFF);
+    }
+
+    #[test]
+    fn slugifies_a_well_formed_address() {
+        let slug = slugify_address("GABCDEFGHIJKLMNOPQRSTUVWXYZ234567");
+        assert_eq!(slug, "u_abcdefghijklmn");
+    }
+
+    #[test]
+    fn falls_back_to_default_slug_for_short_addresses() {
+        assert_eq!(slugify_address(""), DEFAULT_ADDRESS_SLUG);
+        assert_eq!(slugify_address("G"), DEFAULT_ADDRESS_SLUG);
+        assert_eq!(slugify_address("short"), DEFAULT_ADDRESS_SLUG);
+    }
+
+    #[test]
+    fn never_panics_on_multibyte_or_boundary_lengths() {
+        // Multibyte characters must not cause a byte-index panic when slicing.
+        let multibyte: String = std::iter::repeat('é').take(20).collect();
+        assert_eq!(
+            slugify_address(&multibyte),
+            format!("u_{}", "é".repeat(14))
+        );
+
+        // Exactly at the minimum char count boundary (1 skipped + 14 taken).
+        let exact = "G".repeat(15);
+        assert_eq!(slugify_address(&exact), format!("u_{}", "g".repeat(14)));
+
+        // One char short of the boundary falls back to the default slug.
+        let one_short = "G".repeat(14);
+        assert_eq!(slugify_address(&one_short), DEFAULT_ADDRESS_SLUG);
     }
 
     #[test]

--- a/backend/src/services/notifications.rs
+++ b/backend/src/services/notifications.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::Serialize;
 use serde_json::json;
 use sqlx::{PgPool, Row};
+use tokio_cron_scheduler::{Job, JobScheduler};
 use uuid::Uuid;
 
 use crate::db::r#yield::get_current_yield_rate;
@@ -10,8 +11,9 @@ use crate::services::yield_calc::SECONDS_PER_YEAR;
 const EXPO_PUSH_URL: &str = "https://exp.host/--/api/v2/push/send";
 const EXPO_PUSH_BATCH_SIZE: usize = 100;
 const DEFAULT_YIELD_REPORT_THRESHOLD: i64 = 1_000;
-const DEFAULT_DAILY_INTERVAL_SECS: u64 = 86_400;
-const DEFAULT_WEEKLY_INTERVAL_SECS: u64 = 604_800;
+// Cron expressions are `sec min hour day month day-of-week`, evaluated in UTC.
+const DEFAULT_DAILY_CRON: &str = "0 0 0 * * *";
+const DEFAULT_WEEKLY_CRON: &str = "0 0 0 * * Mon";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum YieldReportCadence {
@@ -20,30 +22,26 @@ pub enum YieldReportCadence {
 }
 
 pub struct NotificationSchedulerConfig {
-    pub daily_interval: std::time::Duration,
-    pub weekly_interval: std::time::Duration,
+    pub daily_cron: String,
+    pub weekly_cron: String,
     pub yield_threshold: i64,
     pub expo_access_token: Option<String>,
 }
 
 impl NotificationSchedulerConfig {
     pub fn from_env() -> Self {
-        let daily_secs = std::env::var("YIELD_REPORT_DAILY_INTERVAL_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_DAILY_INTERVAL_SECS);
-        let weekly_secs = std::env::var("YIELD_REPORT_WEEKLY_INTERVAL_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_WEEKLY_INTERVAL_SECS);
+        let daily_cron = std::env::var("YIELD_REPORT_DAILY_CRON")
+            .unwrap_or_else(|_| DEFAULT_DAILY_CRON.to_string());
+        let weekly_cron = std::env::var("YIELD_REPORT_WEEKLY_CRON")
+            .unwrap_or_else(|_| DEFAULT_WEEKLY_CRON.to_string());
         let threshold = std::env::var("YIELD_REPORT_THRESHOLD")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_YIELD_REPORT_THRESHOLD);
 
         Self {
-            daily_interval: std::time::Duration::from_secs(daily_secs),
-            weekly_interval: std::time::Duration::from_secs(weekly_secs),
+            daily_cron,
+            weekly_cron,
             yield_threshold: threshold,
             expo_access_token: std::env::var("EXPO_ACCESS_TOKEN").ok(),
         }
@@ -68,38 +66,79 @@ struct ExpoPushMessage {
     sound: &'static str,
 }
 
-/// BE-032: Fire daily and weekly yield summary push notifications.
+/// BE-032/BE-056: Fire daily and weekly yield summary push notifications at
+/// exact wall-clock times using a cron schedule, rather than an interval
+/// timer that drifts based on process start time.
 pub async fn run(pool: PgPool, config: NotificationSchedulerConfig) {
-    tracing::info!("Starting yield report notification scheduler");
+    tracing::info!(
+        daily_cron = %config.daily_cron,
+        weekly_cron = %config.weekly_cron,
+        "Starting yield report notification scheduler"
+    );
 
-    let daily_pool = pool.clone();
-    let daily_config = config.clone_for_worker();
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(daily_config.daily_interval);
-        loop {
-            interval.tick().await;
-            if let Err(err) =
-                send_yield_reports(&daily_pool, &daily_config, YieldReportCadence::Daily).await
-            {
-                tracing::error!("Daily yield report scheduler failed: {err:?}");
-            }
+    let scheduler = match JobScheduler::new().await {
+        Ok(scheduler) => scheduler,
+        Err(err) => {
+            tracing::error!("Failed to create yield report notification scheduler: {err:?}");
+            return;
         }
-    });
+    };
 
-    let mut weekly_interval = tokio::time::interval(config.weekly_interval);
-    loop {
-        weekly_interval.tick().await;
-        if let Err(err) = send_yield_reports(&pool, &config, YieldReportCadence::Weekly).await {
-            tracing::error!("Weekly yield report scheduler failed: {err:?}");
-        }
+    if let Err(err) = schedule_cadence(&scheduler, &pool, &config, YieldReportCadence::Daily).await
+    {
+        tracing::error!("Failed to schedule daily yield report job: {err:?}");
+        return;
     }
+
+    if let Err(err) =
+        schedule_cadence(&scheduler, &pool, &config, YieldReportCadence::Weekly).await
+    {
+        tracing::error!("Failed to schedule weekly yield report job: {err:?}");
+        return;
+    }
+
+    if let Err(err) = scheduler.start().await {
+        tracing::error!("Failed to start yield report notification scheduler: {err:?}");
+        return;
+    }
+
+    // The scheduler ticks on its own background task; keep this task alive
+    // for as long as the process runs so that task isn't torn down.
+    std::future::pending::<()>().await;
+}
+
+async fn schedule_cadence(
+    scheduler: &JobScheduler,
+    pool: &PgPool,
+    config: &NotificationSchedulerConfig,
+    cadence: YieldReportCadence,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let cron_expr = match cadence {
+        YieldReportCadence::Daily => config.daily_cron.clone(),
+        YieldReportCadence::Weekly => config.weekly_cron.clone(),
+    };
+
+    let job_pool = pool.clone();
+    let job_config = config.clone_for_worker();
+    let job = Job::new_async(cron_expr.as_str(), move |_uuid, _scheduler| {
+        let pool = job_pool.clone();
+        let config = job_config.clone_for_worker();
+        Box::pin(async move {
+            if let Err(err) = send_yield_reports(&pool, &config, cadence).await {
+                tracing::error!(cadence = ?cadence, "Yield report scheduler run failed: {err:?}");
+            }
+        })
+    })?;
+
+    scheduler.add(job).await?;
+    Ok(())
 }
 
 impl NotificationSchedulerConfig {
     fn clone_for_worker(&self) -> Self {
         Self {
-            daily_interval: self.daily_interval,
-            weekly_interval: self.weekly_interval,
+            daily_cron: self.daily_cron.clone(),
+            weekly_cron: self.weekly_cron.clone(),
             yield_threshold: self.yield_threshold,
             expo_access_token: self.expo_access_token.clone(),
         }


### PR DESCRIPTION
oth issues are implemented and verified:

1. Cron-based notification scheduling (backend/src/services/notifications.rs)
- Added tokio-cron-scheduler dependency, replaced the drift-prone tokio::time::interval polling with JobScheduler + Job::new_async, so daily/weekly yield reports fire at exact wall-clock times (UTC) instead of relative to process start.
- NotificationSchedulerConfig now takes daily_cron/weekly_cron cron strings (env vars YIELD_REPORT_DAILY_CRON / YIELD_REPORT_WEEKLY_CRON, defaulting to "0 0 0 * * *" and "0 0 0 * * Mon") instead of interval durations.

2. Panic-safe slugify_address (backend/src/indexer/worker.rs)
- Replaced byte-index slicing with a chars().count() bounds check before slicing, so multibyte or short addresses can never hit a boundary panic.
- Falls back to a u_unknown default slug when the address is too short, per the acceptance criteria.
- Added 3 new tests covering short addresses, multibyte input, and exact boundary lengths.

All 23 unit tests pass and both cargo check/cargo build succeed cleanly.


closes #466
closes #472