### PR TITLE
feat(contract): implement DID updates and address recovery procedures

### DIFF
--- a/contracts/contracts/user_registry/src/lib.rs
+++ b/contracts/contracts/user_registry/src/lib.rs
@@ -8,13 +8,24 @@ pub struct UserRegistryContract;
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
-    User(Address),    // Maps Address -> Username (String)
-    Username(String), // Maps Username (String) -> Address
-    Avatar(Address),  // Maps Address -> Avatar URI (String)
+    User(Address),      // Maps Address -> Username (String)
+    Username(String),   // Maps Username (String) -> Address
+    Avatar(Address),    // Maps Address -> Avatar URI (String)
+    PrivyDid(String),   // Maps Privy DID -> wallet Address
+    WalletDid(Address), // Maps wallet Address -> Privy DID (reverse index)
+    Admin,              // Stores the contract admin Address
 }
 
 #[contractimpl]
 impl UserRegistryContract {
+    /// Initialize the contract with an admin address for recovery operations
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
     /// Register a username mapping to the sender's address
     pub fn register_user(env: Env, user: Address, username: String) {
         user.require_auth();
@@ -69,6 +80,77 @@ impl UserRegistryContract {
             .persistent()
             .get(&DataKey::Avatar(user))
             .unwrap_or_else(|| String::from_str(&env, ""))
+    }
+
+    /// Register a Privy DID → wallet address mapping
+    pub fn register_privy_did(env: Env, did: String, wallet: Address) {
+        wallet.require_auth();
+        let did_key = DataKey::PrivyDid(did.clone());
+        if env.storage().persistent().has(&did_key) {
+            panic!("DID already registered");
+        }
+        env.storage().persistent().set(&did_key, &wallet);
+        env.storage()
+            .persistent()
+            .set(&DataKey::WalletDid(wallet.clone()), &did);
+    }
+
+    /// Update the wallet address for an existing Privy DID mapping.
+    /// Requires authorization from the currently registered (old) wallet address.
+    pub fn update_privy_did(env: Env, did: String, old_wallet: Address, new_wallet: Address) {
+        old_wallet.require_auth();
+        let did_key = DataKey::PrivyDid(did.clone());
+        let stored_wallet: Address = env
+            .storage()
+            .persistent()
+            .get(&did_key)
+            .unwrap_or_else(|| panic!("DID not registered"));
+        if stored_wallet != old_wallet {
+            panic!("unauthorized: old wallet does not match registered wallet");
+        }
+        // Remove old reverse mapping
+        env.storage()
+            .persistent()
+            .remove(&DataKey::WalletDid(old_wallet.clone()));
+        // Update forward and reverse mappings
+        env.storage().persistent().set(&did_key, &new_wallet);
+        env.storage()
+            .persistent()
+            .set(&DataKey::WalletDid(new_wallet.clone()), &did);
+    }
+
+    /// Admin recovery: reassign a DID mapping to a new wallet.
+    /// Requires authorization from the contract admin stored at DataKey::Admin.
+    pub fn recover_privy_did(env: Env, did: String, new_wallet: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("admin not set"));
+        admin.require_auth();
+        let did_key = DataKey::PrivyDid(did.clone());
+        // Remove old reverse mapping if present
+        if let Some(old_wallet) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&did_key)
+        {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::WalletDid(old_wallet));
+        }
+        env.storage().persistent().set(&did_key, &new_wallet);
+        env.storage()
+            .persistent()
+            .set(&DataKey::WalletDid(new_wallet.clone()), &did);
+    }
+
+    /// Get the wallet address registered for a Privy DID
+    pub fn get_wallet_for_did(env: Env, did: String) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PrivyDid(did))
+            .unwrap_or_else(|| panic!("DID not registered"))
     }
 
     /// Unregister a user's profile and mapping


### PR DESCRIPTION
## Summary

- Add `initialize` function to set contract admin
- Add `update_privy_did`: requires old wallet auth to update DID mapping
- Add `recover_privy_did`: admin-authorized recovery to reassign DID to new wallet
- Add `register_privy_did` and `get_wallet_for_did` helpers
- Add `PrivyDid`, `WalletDid`, and `Admin` variants to `DataKey`

## Validation

- No formatter
- No linter
- No typecheck

Closes #536