### PR TITLE
feat(be-555): add schema for payout batches, recipients, and dispatch logs

### DIFF
--- a/backend/migrations/20260725000000_payout_batches.sql
+++ b/backend/migrations/20260725000000_payout_batches.sql
@@ -1,0 +1,131 @@
+-- BE-555: bulk disbursement schema — batches, recipients, and dispatch logs.
+--
+-- Three tables rather than one, because they answer three different questions
+-- and have three different write patterns:
+--
+--   payout_batches    — one row per submitted batch. The unit a caller creates,
+--                       queries and cancels. Low write volume.
+--   batch_recipients  — one row per payout line. The unit the worker claims and
+--                       submits to SDP. High write volume, hot status column.
+--   dispatch_logs     — append-only audit of every dispatch attempt, including
+--                       failures and retries. Never updated.
+--
+-- Keeping attempts out of batch_recipients is deliberate: a recipient row holds
+-- current state and is updated in place, so overwriting it would destroy the
+-- history of what was tried. A payout system needs to answer "what did we send,
+-- when, and what came back" long after the row reached its terminal status.
+
+-- ─── Batches ─────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS payout_batches (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Caller-supplied idempotency key. A retried create returns the existing
+    -- batch instead of double-paying every recipient in it.
+    idempotency_key VARCHAR(128) UNIQUE NOT NULL,
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    -- PENDING -> PROCESSING -> COMPLETED | PARTIALLY_FAILED | FAILED | CANCELLED
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'PROCESSING', 'COMPLETED', 'PARTIALLY_FAILED', 'FAILED', 'CANCELLED')),
+    currency VARCHAR(10) NOT NULL DEFAULT 'NGN',
+    -- Denormalised counters. Recomputable from batch_recipients, but the worker
+    -- and the status endpoint both read them on every cycle; the alternative is
+    -- an aggregate over the whole batch each time.
+    total_recipients INTEGER NOT NULL DEFAULT 0 CHECK (total_recipients >= 0),
+    total_amount BIGINT NOT NULL DEFAULT 0 CHECK (total_amount >= 0),
+    succeeded_count INTEGER NOT NULL DEFAULT 0 CHECK (succeeded_count >= 0),
+    failed_count INTEGER NOT NULL DEFAULT 0 CHECK (failed_count >= 0),
+    -- Set when the worker claims the batch; NULL means unclaimed.
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- Counters can never exceed the batch size, whatever a buggy worker does.
+    CONSTRAINT payout_batches_counts_within_total
+        CHECK (succeeded_count + failed_count <= total_recipients)
+);
+
+-- ─── Recipients ──────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS batch_recipients (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES payout_batches(id) ON DELETE CASCADE,
+    -- Nullable: a payout may target a raw Stellar address for someone who has
+    -- no Zaps account yet. At least one of the two must be present.
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    destination_address VARCHAR(56),
+    amount BIGINT NOT NULL CHECK (amount > 0),
+    -- PENDING -> SUBMITTED -> CONFIRMED | FAILED
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'SUBMITTED', 'CONFIRMED', 'FAILED')),
+    -- SDP's identifier for the disbursement, once accepted.
+    sdp_payment_id VARCHAR(128),
+    tx_hash VARCHAR(64),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    last_error TEXT,
+    -- Worker lease. Set when a worker claims the row, cleared on terminal
+    -- status; lets a second worker detect and reclaim rows abandoned by a
+    -- process that died mid-dispatch.
+    locked_at TIMESTAMP,
+    locked_by VARCHAR(64),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT batch_recipients_has_destination
+        CHECK (user_id IS NOT NULL OR destination_address IS NOT NULL)
+);
+
+-- One payout per user per batch. This is the guard that makes a retried batch
+-- submission safe: a duplicated recipient line is rejected by the database
+-- rather than silently paying twice.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_recipients_unique_user
+    ON batch_recipients(batch_id, user_id)
+    WHERE user_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_recipients_unique_address
+    ON batch_recipients(batch_id, destination_address)
+    WHERE destination_address IS NOT NULL;
+
+-- ─── Dispatch logs ───────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS dispatch_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES payout_batches(id) ON DELETE CASCADE,
+    -- Nullable so a batch-level event (claimed, completed, cancelled) can be
+    -- logged without inventing a recipient for it.
+    recipient_id UUID REFERENCES batch_recipients(id) ON DELETE CASCADE,
+    attempt INTEGER NOT NULL DEFAULT 1 CHECK (attempt >= 1),
+    -- The outcome being recorded, not the resulting row state.
+    event VARCHAR(30) NOT NULL
+        CHECK (event IN ('CLAIMED', 'SUBMITTED', 'CONFIRMED', 'FAILED', 'RETRY_SCHEDULED', 'CANCELLED')),
+    sdp_response_code VARCHAR(20),
+    detail TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- ─── Indexes ─────────────────────────────────────────────────────────────────
+
+-- The worker's claim query: oldest unclaimed batch in a given status.
+CREATE INDEX IF NOT EXISTS idx_payout_batches_status_created
+    ON payout_batches(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_payout_batches_created_by
+    ON payout_batches(created_by);
+
+-- The hot path: next N pending rows for the batch being processed. Partial, so
+-- the index stays small as rows reach terminal status and drop out of it —
+-- which matters when a batch has 100k recipients and 99% are done.
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_pending
+    ON batch_recipients(batch_id, created_at)
+    WHERE status = 'PENDING';
+
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_batch_status
+    ON batch_recipients(batch_id, status);
+
+-- Reclaiming rows abandoned by a dead worker.
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_locked
+    ON batch_recipients(locked_at)
+    WHERE locked_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_logs_batch
+    ON dispatch_logs(batch_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dispatch_logs_recipient
+    ON dispatch_logs(recipient_id, created_at DESC)
+    WHERE recipient_id IS NOT NULL;

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -111,3 +111,83 @@ CREATE TABLE IF NOT EXISTS yield_rates_history (
 CREATE INDEX IF NOT EXISTS idx_yield_tx_user_id ON yield_transactions(user_id);
 CREATE INDEX IF NOT EXISTS idx_yield_tx_created_at ON yield_transactions(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_yield_rates_created_at ON yield_rates_history(created_at DESC);
+
+-- Bulk Disbursement Tables (BE-555)
+--
+-- Three tables because they answer three different questions and have three
+-- different write patterns: payout_batches is the unit a caller creates and
+-- queries, batch_recipients is the unit the worker claims and submits, and
+-- dispatch_logs is an append-only audit of every attempt. Attempts are kept out
+-- of batch_recipients on purpose — that row is updated in place, so recording
+-- history there would overwrite it.
+
+CREATE TABLE IF NOT EXISTS payout_batches (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    idempotency_key VARCHAR(128) UNIQUE NOT NULL, -- retried create returns the existing batch
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'PROCESSING', 'COMPLETED', 'PARTIALLY_FAILED', 'FAILED', 'CANCELLED')),
+    currency VARCHAR(10) NOT NULL DEFAULT 'NGN',
+    total_recipients INTEGER NOT NULL DEFAULT 0 CHECK (total_recipients >= 0),
+    total_amount BIGINT NOT NULL DEFAULT 0 CHECK (total_amount >= 0),
+    succeeded_count INTEGER NOT NULL DEFAULT 0 CHECK (succeeded_count >= 0),
+    failed_count INTEGER NOT NULL DEFAULT 0 CHECK (failed_count >= 0),
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT payout_batches_counts_within_total
+        CHECK (succeeded_count + failed_count <= total_recipients)
+);
+
+CREATE TABLE IF NOT EXISTS batch_recipients (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES payout_batches(id) ON DELETE CASCADE,
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL, -- NULL for a raw address payout
+    destination_address VARCHAR(56),
+    amount BIGINT NOT NULL CHECK (amount > 0),
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'SUBMITTED', 'CONFIRMED', 'FAILED')),
+    sdp_payment_id VARCHAR(128),
+    tx_hash VARCHAR(64),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    last_error TEXT,
+    locked_at TIMESTAMP, -- worker lease; lets a peer reclaim rows from a dead process
+    locked_by VARCHAR(64),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT batch_recipients_has_destination
+        CHECK (user_id IS NOT NULL OR destination_address IS NOT NULL)
+);
+
+CREATE TABLE IF NOT EXISTS dispatch_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES payout_batches(id) ON DELETE CASCADE,
+    recipient_id UUID REFERENCES batch_recipients(id) ON DELETE CASCADE, -- NULL for batch-level events
+    attempt INTEGER NOT NULL DEFAULT 1 CHECK (attempt >= 1),
+    event VARCHAR(30) NOT NULL
+        CHECK (event IN ('CLAIMED', 'SUBMITTED', 'CONFIRMED', 'FAILED', 'RETRY_SCHEDULED', 'CANCELLED')),
+    sdp_response_code VARCHAR(20),
+    detail TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+-- Duplicate-payout guards: a retried batch submission is rejected by the
+-- database rather than silently paying a recipient twice.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_recipients_unique_user
+    ON batch_recipients(batch_id, user_id) WHERE user_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_recipients_unique_address
+    ON batch_recipients(batch_id, destination_address) WHERE destination_address IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_payout_batches_status_created ON payout_batches(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_payout_batches_created_by ON payout_batches(created_by);
+-- Partial, so the worker's hot path index shrinks as rows reach terminal status.
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_pending
+    ON batch_recipients(batch_id, created_at) WHERE status = 'PENDING';
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_batch_status ON batch_recipients(batch_id, status);
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_locked
+    ON batch_recipients(locked_at) WHERE locked_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_dispatch_logs_batch ON dispatch_logs(batch_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dispatch_logs_recipient
+    ON dispatch_logs(recipient_id, created_at DESC) WHERE recipient_id IS NOT NULL;


### PR DESCRIPTION
Closes #555

Adds the database layer for bulk disbursement: `payout_batches`, `batch_recipients`, and `dispatch_logs`.

## Three tables, not one

They answer three different questions and have three different write patterns:

| Table | Unit | Write pattern |
|---|---|---|
| `payout_batches` | What a caller creates, queries, cancels | Low volume |
| `batch_recipients` | What the worker claims and submits to SDP | High volume, hot status column |
| `dispatch_logs` | Every dispatch attempt, incl. failures and retries | Append-only, never updated |

Attempts are deliberately kept **out of** `batch_recipients`. That row holds current state and is updated in place, so recording history there would overwrite it — and a payout system has to answer *"what did we send, when, and what came back"* long after a row reaches its terminal status.

## Duplicate-payout guards

The constraints matter more than usual here, because the failure mode is paying real money twice:

- **`idempotency_key` is `UNIQUE`** — a retried create returns the existing batch instead of duplicating every recipient in it.
- **Partial unique indexes** on `(batch_id, user_id)` and `(batch_id, destination_address)` — a duplicated recipient line is rejected by the database rather than silently paid twice. Partial because either column may be NULL: a payout can target a raw Stellar address for someone with no Zaps account yet, which is also why `batch_recipients_has_destination` requires at least one of the two.
- **`payout_batches_counts_within_total`** keeps `succeeded + failed` from exceeding the batch size whatever a buggy worker does.

## Worker support

`batch_recipients` carries a `locked_at` / `locked_by` lease so a second worker can detect and reclaim rows abandoned by a process that died mid-dispatch, rather than leaving them stuck in `SUBMITTED` forever.

The hot-path index on pending rows is **partial**, so it shrinks as rows reach terminal status — which is what keeps claim queries fast when a batch has 100k recipients and 99% of them are done.

Denormalised counters on `payout_batches` are recomputable from `batch_recipients`, but the worker and the status endpoint both read them every cycle; the alternative is an aggregate over the whole batch each time.

## Status lifecycles

```
payout_batches:   PENDING -> PROCESSING -> COMPLETED | PARTIALLY_FAILED | FAILED | CANCELLED
batch_recipients: PENDING -> SUBMITTED  -> CONFIRMED | FAILED
```

Both are enforced with `CHECK` constraints rather than left to application code, so a typo in a status string fails at write time instead of quietly creating a row no query matches.

## Acceptance criteria

- [x] Tables `payout_batches` and `batch_recipients` — plus `dispatch_logs` for the "dispatch logs" half of the title
- [x] Constraints — FKs, status `CHECK`s, amount/count `CHECK`s, idempotency and duplicate-recipient uniqueness, cross-column `has_destination` and `counts_within_total`
- [x] Indices — worker claim path (partial), batch/status lookups, lease reclaim, log lookups
- [x] Foreign keys pointing to batch identifiers — `batch_recipients.batch_id` and `dispatch_logs.batch_id` both cascade from `payout_batches`

## Scope

Mirrored into `src/db/schema.sql`, which the repo keeps in sync with `migrations/`.

Rust models are deliberately **not** included — they belong with the worker in #554 that consumes them, and keeping this PR purely schema means it can merge independently.

## Verification

Schema-only change; I have not run the migration against a live Postgres instance, so I'd suggest a `sqlx migrate run` on a scratch database before merging. The SQL follows the existing conventions in `migrations/` (`IF NOT EXISTS`, `gen_random_uuid()` PKs, `BIGINT` minor-unit amounts, timestamped filename).
