### PR TITLE
feat(be-554): add queue worker for bulk disbursement batches

### DIFF
--- a/backend/migrations/20260725000000_payout_batches.sql
+++ b/backend/migrations/20260725000000_payout_batches.sql
@@ -1,0 +1,131 @@
+-- BE-555: bulk disbursement schema — batches, recipients, and dispatch logs.
+--
+-- Three tables rather than one, because they answer three different questions
+-- and have three different write patterns:
+--
+--   payout_batches    — one row per submitted batch. The unit a caller creates,
+--                       queries and cancels. Low write volume.
+--   batch_recipients  — one row per payout line. The unit the worker claims and
+--                       submits to SDP. High write volume, hot status column.
+--   dispatch_logs     — append-only audit of every dispatch attempt, including
+--                       failures and retries. Never updated.
+--
+-- Keeping attempts out of batch_recipients is deliberate: a recipient row holds
+-- current state and is updated in place, so overwriting it would destroy the
+-- history of what was tried. A payout system needs to answer "what did we send,
+-- when, and what came back" long after the row reached its terminal status.
+
+-- ─── Batches ─────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS payout_batches (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Caller-supplied idempotency key. A retried create returns the existing
+    -- batch instead of double-paying every recipient in it.
+    idempotency_key VARCHAR(128) UNIQUE NOT NULL,
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    -- PENDING -> PROCESSING -> COMPLETED | PARTIALLY_FAILED | FAILED | CANCELLED
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'PROCESSING', 'COMPLETED', 'PARTIALLY_FAILED', 'FAILED', 'CANCELLED')),
+    currency VARCHAR(10) NOT NULL DEFAULT 'NGN',
+    -- Denormalised counters. Recomputable from batch_recipients, but the worker
+    -- and the status endpoint both read them on every cycle; the alternative is
+    -- an aggregate over the whole batch each time.
+    total_recipients INTEGER NOT NULL DEFAULT 0 CHECK (total_recipients >= 0),
+    total_amount BIGINT NOT NULL DEFAULT 0 CHECK (total_amount >= 0),
+    succeeded_count INTEGER NOT NULL DEFAULT 0 CHECK (succeeded_count >= 0),
+    failed_count INTEGER NOT NULL DEFAULT 0 CHECK (failed_count >= 0),
+    -- Set when the worker claims the batch; NULL means unclaimed.
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- Counters can never exceed the batch size, whatever a buggy worker does.
+    CONSTRAINT payout_batches_counts_within_total
+        CHECK (succeeded_count + failed_count <= total_recipients)
+);
+
+-- ─── Recipients ──────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS batch_recipients (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES payout_batches(id) ON DELETE CASCADE,
+    -- Nullable: a payout may target a raw Stellar address for someone who has
+    -- no Zaps account yet. At least one of the two must be present.
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    destination_address VARCHAR(56),
+    amount BIGINT NOT NULL CHECK (amount > 0),
+    -- PENDING -> SUBMITTED -> CONFIRMED | FAILED
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'SUBMITTED', 'CONFIRMED', 'FAILED')),
+    -- SDP's identifier for the disbursement, once accepted.
+    sdp_payment_id VARCHAR(128),
+    tx_hash VARCHAR(64),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    last_error TEXT,
+    -- Worker lease. Set when a worker claims the row, cleared on terminal
+    -- status; lets a second worker detect and reclaim rows abandoned by a
+    -- process that died mid-dispatch.
+    locked_at TIMESTAMP,
+    locked_by VARCHAR(64),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT batch_recipients_has_destination
+        CHECK (user_id IS NOT NULL OR destination_address IS NOT NULL)
+);
+
+-- One payout per user per batch. This is the guard that makes a retried batch
+-- submission safe: a duplicated recipient line is rejected by the database
+-- rather than silently paying twice.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_recipients_unique_user
+    ON batch_recipients(batch_id, user_id)
+    WHERE user_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_recipients_unique_address
+    ON batch_recipients(batch_id, destination_address)
+    WHERE destination_address IS NOT NULL;
+
+-- ─── Dispatch logs ───────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS dispatch_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES payout_batches(id) ON DELETE CASCADE,
+    -- Nullable so a batch-level event (claimed, completed, cancelled) can be
+    -- logged without inventing a recipient for it.
+    recipient_id UUID REFERENCES batch_recipients(id) ON DELETE CASCADE,
+    attempt INTEGER NOT NULL DEFAULT 1 CHECK (attempt >= 1),
+    -- The outcome being recorded, not the resulting row state.
+    event VARCHAR(30) NOT NULL
+        CHECK (event IN ('CLAIMED', 'SUBMITTED', 'CONFIRMED', 'FAILED', 'RETRY_SCHEDULED', 'CANCELLED')),
+    sdp_response_code VARCHAR(20),
+    detail TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- ─── Indexes ─────────────────────────────────────────────────────────────────
+
+-- The worker's claim query: oldest unclaimed batch in a given status.
+CREATE INDEX IF NOT EXISTS idx_payout_batches_status_created
+    ON payout_batches(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_payout_batches_created_by
+    ON payout_batches(created_by);
+
+-- The hot path: next N pending rows for the batch being processed. Partial, so
+-- the index stays small as rows reach terminal status and drop out of it —
+-- which matters when a batch has 100k recipients and 99% are done.
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_pending
+    ON batch_recipients(batch_id, created_at)
+    WHERE status = 'PENDING';
+
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_batch_status
+    ON batch_recipients(batch_id, status);
+
+-- Reclaiming rows abandoned by a dead worker.
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_locked
+    ON batch_recipients(locked_at)
+    WHERE locked_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_logs_batch
+    ON dispatch_logs(batch_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dispatch_logs_recipient
+    ON dispatch_logs(recipient_id, created_at DESC)
+    WHERE recipient_id IS NOT NULL;

--- a/backend/src/db/models.rs
+++ b/backend/src/db/models.rs
@@ -92,3 +92,57 @@ pub struct YieldRateHistory {
     pub apy: i32,
     pub created_at: NaiveDateTime,
 }
+
+// ─── Bulk disbursement (BE-554 / BE-555) ─────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct PayoutBatch {
+    pub id: Uuid,
+    pub idempotency_key: String,
+    pub created_by: Uuid,
+    /// PENDING, PROCESSING, COMPLETED, PARTIALLY_FAILED, FAILED, CANCELLED
+    pub status: String,
+    pub currency: String,
+    pub total_recipients: i32,
+    pub total_amount: i64,
+    pub succeeded_count: i32,
+    pub failed_count: i32,
+    pub started_at: Option<NaiveDateTime>,
+    pub completed_at: Option<NaiveDateTime>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct BatchRecipient {
+    pub id: Uuid,
+    pub batch_id: Uuid,
+    /// `None` when the payout targets a raw Stellar address rather than a
+    /// registered Zaps user.
+    pub user_id: Option<Uuid>,
+    pub destination_address: Option<String>,
+    pub amount: i64,
+    /// PENDING, SUBMITTED, CONFIRMED, FAILED
+    pub status: String,
+    pub sdp_payment_id: Option<String>,
+    pub tx_hash: Option<String>,
+    pub attempt_count: i32,
+    pub last_error: Option<String>,
+    pub locked_at: Option<NaiveDateTime>,
+    pub locked_by: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct DispatchLog {
+    pub id: Uuid,
+    pub batch_id: Uuid,
+    pub recipient_id: Option<Uuid>,
+    pub attempt: i32,
+    /// CLAIMED, SUBMITTED, CONFIRMED, FAILED, RETRY_SCHEDULED, CANCELLED
+    pub event: String,
+    pub sdp_response_code: Option<String>,
+    pub detail: Option<String>,
+    pub created_at: NaiveDateTime,
+}

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -111,3 +111,83 @@ CREATE TABLE IF NOT EXISTS yield_rates_history (
 CREATE INDEX IF NOT EXISTS idx_yield_tx_user_id ON yield_transactions(user_id);
 CREATE INDEX IF NOT EXISTS idx_yield_tx_created_at ON yield_transactions(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_yield_rates_created_at ON yield_rates_history(created_at DESC);
+
+-- Bulk Disbursement Tables (BE-555)
+--
+-- Three tables because they answer three different questions and have three
+-- different write patterns: payout_batches is the unit a caller creates and
+-- queries, batch_recipients is the unit the worker claims and submits, and
+-- dispatch_logs is an append-only audit of every attempt. Attempts are kept out
+-- of batch_recipients on purpose — that row is updated in place, so recording
+-- history there would overwrite it.
+
+CREATE TABLE IF NOT EXISTS payout_batches (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    idempotency_key VARCHAR(128) UNIQUE NOT NULL, -- retried create returns the existing batch
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'PROCESSING', 'COMPLETED', 'PARTIALLY_FAILED', 'FAILED', 'CANCELLED')),
+    currency VARCHAR(10) NOT NULL DEFAULT 'NGN',
+    total_recipients INTEGER NOT NULL DEFAULT 0 CHECK (total_recipients >= 0),
+    total_amount BIGINT NOT NULL DEFAULT 0 CHECK (total_amount >= 0),
+    succeeded_count INTEGER NOT NULL DEFAULT 0 CHECK (succeeded_count >= 0),
+    failed_count INTEGER NOT NULL DEFAULT 0 CHECK (failed_count >= 0),
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT payout_batches_counts_within_total
+        CHECK (succeeded_count + failed_count <= total_recipients)
+);
+
+CREATE TABLE IF NOT EXISTS batch_recipients (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES payout_batches(id) ON DELETE CASCADE,
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL, -- NULL for a raw address payout
+    destination_address VARCHAR(56),
+    amount BIGINT NOT NULL CHECK (amount > 0),
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'SUBMITTED', 'CONFIRMED', 'FAILED')),
+    sdp_payment_id VARCHAR(128),
+    tx_hash VARCHAR(64),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    last_error TEXT,
+    locked_at TIMESTAMP, -- worker lease; lets a peer reclaim rows from a dead process
+    locked_by VARCHAR(64),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT batch_recipients_has_destination
+        CHECK (user_id IS NOT NULL OR destination_address IS NOT NULL)
+);
+
+CREATE TABLE IF NOT EXISTS dispatch_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES payout_batches(id) ON DELETE CASCADE,
+    recipient_id UUID REFERENCES batch_recipients(id) ON DELETE CASCADE, -- NULL for batch-level events
+    attempt INTEGER NOT NULL DEFAULT 1 CHECK (attempt >= 1),
+    event VARCHAR(30) NOT NULL
+        CHECK (event IN ('CLAIMED', 'SUBMITTED', 'CONFIRMED', 'FAILED', 'RETRY_SCHEDULED', 'CANCELLED')),
+    sdp_response_code VARCHAR(20),
+    detail TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+-- Duplicate-payout guards: a retried batch submission is rejected by the
+-- database rather than silently paying a recipient twice.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_recipients_unique_user
+    ON batch_recipients(batch_id, user_id) WHERE user_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_recipients_unique_address
+    ON batch_recipients(batch_id, destination_address) WHERE destination_address IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_payout_batches_status_created ON payout_batches(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_payout_batches_created_by ON payout_batches(created_by);
+-- Partial, so the worker's hot path index shrinks as rows reach terminal status.
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_pending
+    ON batch_recipients(batch_id, created_at) WHERE status = 'PENDING';
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_batch_status ON batch_recipients(batch_id, status);
+CREATE INDEX IF NOT EXISTS idx_batch_recipients_locked
+    ON batch_recipients(locked_at) WHERE locked_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_dispatch_logs_batch ON dispatch_logs(batch_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dispatch_logs_recipient
+    ON dispatch_logs(recipient_id, created_at DESC) WHERE recipient_id IS NOT NULL;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -297,6 +297,14 @@ async fn main() {
         services::sweep_worker::run(sweep_pool, sweep_config).await;
     });
 
+    // BE-554: Drain bulk disbursement batches asynchronously so an HTTP request
+    // never blocks on thousands of sequential SDP submissions.
+    let disbursement_pool = pool.clone();
+    let disbursement_config = services::disbursement_worker::DisbursementWorkerConfig::from_env();
+    tokio::spawn(async move {
+        services::disbursement_worker::run(disbursement_pool, disbursement_config).await;
+    });
+
     // BE-032: Daily / weekly yield report push notifications.
     let notification_pool = pool.clone();
     let notification_config = services::notifications::NotificationSchedulerConfig::from_env();

--- a/backend/src/services/disbursement_worker.rs
+++ b/backend/src/services/disbursement_worker.rs
@@ -1,0 +1,648 @@
+//! BE-554: background queue worker for bulk disbursement batches.
+//!
+//! Callers create a `payout_batches` row with its `batch_recipients`; this
+//! worker drains them asynchronously so an HTTP request never blocks on
+//! thousands of sequential SDP submissions.
+//!
+//! ## Why the database is the queue
+//!
+//! The issue suggests a DB-backed task list or Redis streams. This uses the
+//! database, for one reason: the payout rows and the queue state have to move
+//! together. With Redis the job and the row it describes live in separate
+//! systems, and a crash between "SDP accepted the payment" and "Redis acked the
+//! job" leaves them disagreeing — which for a payout system means paying twice
+//! or not at all. `SELECT ... FOR UPDATE SKIP LOCKED` gives the same
+//! competing-consumer semantics with the claim in the same transaction as the
+//! state it guards, and adds no new infrastructure.
+//!
+//! ## Delivery semantics
+//!
+//! At-least-once, made safe by idempotency rather than by trying to be
+//! exactly-once:
+//!
+//! - Recipients are claimed with `SKIP LOCKED`, so N workers never hand the same
+//!   row to SDP twice concurrently.
+//! - Each submission carries a deterministic idempotency key derived from the
+//!   recipient row id, so a retry after an ambiguous failure is deduplicated by
+//!   SDP rather than paying again.
+//! - A row that fails is retried up to `max_attempts`, then marked FAILED and
+//!   left alone. A permanently-failing recipient must not block the batch.
+//!
+//! ## Ordering
+//!
+//! Submissions within a batch are sequential, as the issue requires. That is
+//! deliberate beyond just following the spec: SDP applies rate limits per
+//! account, and a burst of parallel submissions from one source account
+//! produces sequence-number contention on the Stellar side.
+
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::db::models::BatchRecipient;
+
+const DEFAULT_POLL_INTERVAL_SECS: u64 = 15;
+const DEFAULT_MAX_ATTEMPTS: i32 = 3;
+/// Recipients claimed per cycle. Bounded so a 100k-recipient batch does not
+/// hold a single transaction open for its entire duration.
+const DEFAULT_CLAIM_SIZE: i64 = 100;
+/// A claim older than this is assumed to belong to a dead worker.
+const DEFAULT_LEASE_TIMEOUT_SECS: i64 = 900;
+
+pub struct DisbursementWorkerConfig {
+    pub poll_interval: Duration,
+    pub max_attempts: i32,
+    pub claim_size: i64,
+    pub lease_timeout_secs: i64,
+    /// SDP API base URL, e.g. `https://sdp.example.org`.
+    pub sdp_base_url: String,
+    /// Bearer token for the SDP API. Without it the worker runs in dry-run mode.
+    pub sdp_api_token: Option<String>,
+    /// Identifies this process in `batch_recipients.locked_by`.
+    pub worker_id: String,
+}
+
+impl DisbursementWorkerConfig {
+    pub fn from_env() -> Self {
+        let poll_secs = std::env::var("DISBURSEMENT_POLL_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_POLL_INTERVAL_SECS);
+        let max_attempts = std::env::var("DISBURSEMENT_MAX_ATTEMPTS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_MAX_ATTEMPTS);
+        let claim_size = std::env::var("DISBURSEMENT_CLAIM_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_CLAIM_SIZE);
+        let lease_timeout_secs = std::env::var("DISBURSEMENT_LEASE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_LEASE_TIMEOUT_SECS);
+        let sdp_base_url = std::env::var("SDP_BASE_URL")
+            .unwrap_or_else(|_| "https://sdp.stellar.org".into());
+        let sdp_api_token = std::env::var("SDP_API_TOKEN").ok();
+        // Hostname keeps lock ownership meaningful across replicas; the uuid
+        // suffix disambiguates multiple workers on the same host.
+        let worker_id = format!(
+            "{}-{}",
+            std::env::var("HOSTNAME").unwrap_or_else(|_| "worker".into()),
+            Uuid::new_v4()
+        );
+
+        Self {
+            poll_interval: Duration::from_secs(poll_secs),
+            max_attempts,
+            claim_size,
+            lease_timeout_secs,
+            sdp_base_url,
+            sdp_api_token,
+            worker_id,
+        }
+    }
+}
+
+/// Payload posted to SDP for a single disbursement.
+#[derive(Debug, Serialize)]
+struct SdpDisbursementRequest<'a> {
+    /// Deterministic per-recipient key. SDP deduplicates on this, which is what
+    /// makes an at-least-once retry safe.
+    idempotency_key: String,
+    destination: &'a str,
+    amount: i64,
+    currency: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct SdpDisbursementResponse {
+    #[serde(default)]
+    payment_id: Option<String>,
+    #[serde(default)]
+    tx_hash: Option<String>,
+}
+
+/// Outcome of one dispatch attempt.
+enum DispatchOutcome {
+    Submitted {
+        sdp_payment_id: Option<String>,
+        tx_hash: Option<String>,
+    },
+    /// Transient — worth another attempt.
+    Retryable(String),
+    /// Permanent — retrying will not help (bad address, rejected amount).
+    Permanent(String),
+}
+
+/// Entry point. Runs until the process exits.
+pub async fn run(pool: PgPool, config: DisbursementWorkerConfig) {
+    tracing::info!(
+        worker_id = %config.worker_id,
+        "Starting disbursement worker (interval={:?}, claim_size={}, max_attempts={})",
+        config.poll_interval,
+        config.claim_size,
+        config.max_attempts
+    );
+
+    if config.sdp_api_token.is_none() {
+        tracing::warn!(
+            "SDP_API_TOKEN not set; disbursement worker running in dry-run mode \
+             (recipients will be marked SUBMITTED without contacting SDP)"
+        );
+    }
+
+    let http = reqwest::Client::new();
+    let mut interval = tokio::time::interval(config.poll_interval);
+
+    loop {
+        interval.tick().await;
+
+        if let Err(err) = reclaim_stale_leases(&pool, config.lease_timeout_secs).await {
+            tracing::error!("Failed to reclaim stale leases: {err:?}");
+        }
+
+        if let Err(err) = process_cycle(&pool, &config, &http).await {
+            tracing::error!("Disbursement cycle failed: {err:?}");
+        }
+    }
+}
+
+/// Releases claims held by workers that died mid-dispatch.
+///
+/// Without this a crashed worker's rows stay locked forever and the batch never
+/// completes. `attempt_count` is left as-is so a row that keeps killing its
+/// worker still exhausts its retries rather than looping indefinitely.
+async fn reclaim_stale_leases(pool: &PgPool, lease_timeout_secs: i64) -> Result<(), sqlx::Error> {
+    let reclaimed = sqlx::query(
+        r#"
+        UPDATE batch_recipients
+           SET locked_at = NULL,
+               locked_by = NULL,
+               updated_at = NOW()
+         WHERE status = 'PENDING'
+           AND locked_at IS NOT NULL
+           AND locked_at < NOW() - ($1 || ' seconds')::interval
+        "#,
+    )
+    .bind(lease_timeout_secs.to_string())
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    if reclaimed > 0 {
+        tracing::warn!("Reclaimed {reclaimed} recipient(s) from expired worker leases");
+    }
+    Ok(())
+}
+
+/// Claims one batch and drains up to `claim_size` of its recipients.
+async fn process_cycle(
+    pool: &PgPool,
+    config: &DisbursementWorkerConfig,
+    http: &reqwest::Client,
+) -> Result<(), sqlx::Error> {
+    let Some(batch_id) = claim_next_batch(pool, &config.worker_id).await? else {
+        tracing::debug!("Disbursement: no batches awaiting processing");
+        return Ok(());
+    };
+
+    let recipients = claim_recipients(pool, batch_id, config).await?;
+    if recipients.is_empty() {
+        // Nothing left to send — settle the batch's terminal status.
+        finalize_batch(pool, batch_id).await?;
+        return Ok(());
+    }
+
+    tracing::info!(
+        batch_id = %batch_id,
+        count = recipients.len(),
+        "Dispatching payout batch"
+    );
+
+    // Sequential on purpose: SDP rate-limits per account, and parallel
+    // submissions from one source account contend on the Stellar sequence
+    // number.
+    for recipient in recipients {
+        let attempt = recipient.attempt_count + 1;
+        let outcome = dispatch_one(&recipient, config, http).await;
+
+        match outcome {
+            DispatchOutcome::Submitted {
+                sdp_payment_id,
+                tx_hash,
+            } => {
+                mark_submitted(pool, &recipient, sdp_payment_id.as_deref(), tx_hash.as_deref())
+                    .await?;
+                log_dispatch(pool, batch_id, Some(recipient.id), attempt, "SUBMITTED", None, None)
+                    .await?;
+            }
+            DispatchOutcome::Retryable(err) if attempt < config.max_attempts => {
+                mark_retry(pool, &recipient, &err).await?;
+                log_dispatch(
+                    pool,
+                    batch_id,
+                    Some(recipient.id),
+                    attempt,
+                    "RETRY_SCHEDULED",
+                    None,
+                    Some(&err),
+                )
+                .await?;
+            }
+            DispatchOutcome::Retryable(err) | DispatchOutcome::Permanent(err) => {
+                // Either permanently bad, or out of retries. Fail this row only
+                // — one dead recipient must not strand the rest of the batch.
+                mark_failed(pool, &recipient, &err).await?;
+                log_dispatch(
+                    pool,
+                    batch_id,
+                    Some(recipient.id),
+                    attempt,
+                    "FAILED",
+                    None,
+                    Some(&err),
+                )
+                .await?;
+            }
+        }
+    }
+
+    finalize_batch(pool, batch_id).await?;
+    Ok(())
+}
+
+/// Claims the oldest batch awaiting work.
+///
+/// `FOR UPDATE SKIP LOCKED` is what makes this safe to run on N replicas: a
+/// batch already being claimed by a peer is skipped rather than blocking.
+async fn claim_next_batch(pool: &PgPool, worker_id: &str) -> Result<Option<Uuid>, sqlx::Error> {
+    let row: Option<(Uuid,)> = sqlx::query_as(
+        r#"
+        WITH next_batch AS (
+            SELECT id
+              FROM payout_batches
+             WHERE status IN ('PENDING', 'PROCESSING')
+             ORDER BY created_at
+             FOR UPDATE SKIP LOCKED
+             LIMIT 1
+        )
+        UPDATE payout_batches b
+           SET status = 'PROCESSING',
+               started_at = COALESCE(b.started_at, NOW()),
+               updated_at = NOW()
+          FROM next_batch
+         WHERE b.id = next_batch.id
+        RETURNING b.id
+        "#,
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    if let Some((batch_id,)) = row {
+        log_dispatch(pool, batch_id, None, 1, "CLAIMED", None, Some(worker_id)).await?;
+        return Ok(Some(batch_id));
+    }
+    Ok(None)
+}
+
+/// Claims a bounded slice of a batch's pending recipients.
+async fn claim_recipients(
+    pool: &PgPool,
+    batch_id: Uuid,
+    config: &DisbursementWorkerConfig,
+) -> Result<Vec<BatchRecipient>, sqlx::Error> {
+    sqlx::query_as::<_, BatchRecipient>(
+        r#"
+        WITH claimed AS (
+            SELECT id
+              FROM batch_recipients
+             WHERE batch_id = $1
+               AND status = 'PENDING'
+               AND locked_at IS NULL
+             ORDER BY created_at
+             FOR UPDATE SKIP LOCKED
+             LIMIT $2
+        )
+        UPDATE batch_recipients r
+           SET locked_at = NOW(),
+               locked_by = $3,
+               updated_at = NOW()
+          FROM claimed
+         WHERE r.id = claimed.id
+        RETURNING r.*
+        "#,
+    )
+    .bind(batch_id)
+    .bind(config.claim_size)
+    .bind(&config.worker_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// Submits a single recipient to SDP.
+async fn dispatch_one(
+    recipient: &BatchRecipient,
+    config: &DisbursementWorkerConfig,
+    http: &reqwest::Client,
+) -> DispatchOutcome {
+    let Some(destination) = recipient.destination_address.as_deref() else {
+        // The schema guarantees a user_id when there is no address, but this
+        // worker sends to addresses. A row that reached here without one was
+        // never resolvable, so retrying cannot help.
+        return DispatchOutcome::Permanent(
+            "recipient has no destination_address; resolve user_id to an address first".into(),
+        );
+    };
+
+    let Some(token) = config.sdp_api_token.as_deref() else {
+        // Dry run: exercise the full state machine without moving money.
+        return DispatchOutcome::Submitted {
+            sdp_payment_id: Some(format!("dry-run-{}", recipient.id)),
+            tx_hash: None,
+        };
+    };
+
+    let request = SdpDisbursementRequest {
+        // Derived from the row id, not from the attempt: every retry of this
+        // recipient reuses the same key so SDP deduplicates instead of paying
+        // again.
+        idempotency_key: idempotency_key_for(recipient.id),
+        destination,
+        amount: recipient.amount,
+        currency: "USDC",
+    };
+
+    let response = http
+        .post(format!("{}/disbursements", config.sdp_base_url.trim_end_matches('/')))
+        .bearer_auth(token)
+        .json(&request)
+        .send()
+        .await;
+
+    let response = match response {
+        Ok(r) => r,
+        // Network-level failure: no way to know whether SDP saw it, so retry
+        // and let the idempotency key deduplicate.
+        Err(err) => return DispatchOutcome::Retryable(format!("SDP request failed: {err}")),
+    };
+
+    let status = response.status();
+    if status.is_success() {
+        return match response.json::<SdpDisbursementResponse>().await {
+            Ok(body) => DispatchOutcome::Submitted {
+                sdp_payment_id: body.payment_id,
+                tx_hash: body.tx_hash,
+            },
+            // SDP accepted it; we just could not parse the body. Treating this
+            // as a failure would risk a double payment on retry, so record the
+            // submission and let reconciliation fill in the ids.
+            Err(err) => {
+                tracing::warn!(
+                    recipient_id = %recipient.id,
+                    error = ?err,
+                    "SDP returned success with an unparseable body"
+                );
+                DispatchOutcome::Submitted {
+                    sdp_payment_id: None,
+                    tx_hash: None,
+                }
+            }
+        };
+    }
+
+    let detail = response.text().await.unwrap_or_default();
+
+    // 4xx other than 408/429 means SDP rejected the request itself — a bad
+    // address or a malformed amount will be rejected identically forever.
+    if status.is_client_error()
+        && status != reqwest::StatusCode::REQUEST_TIMEOUT
+        && status != reqwest::StatusCode::TOO_MANY_REQUESTS
+    {
+        return DispatchOutcome::Permanent(format!("SDP rejected request ({status}): {detail}"));
+    }
+
+    DispatchOutcome::Retryable(format!("SDP error ({status}): {detail}"))
+}
+
+/// Deterministic idempotency key for a recipient row.
+pub fn idempotency_key_for(recipient_id: Uuid) -> String {
+    format!("zaps-payout-{recipient_id}")
+}
+
+// ─── State transitions ───────────────────────────────────────────────────────
+
+async fn mark_submitted(
+    pool: &PgPool,
+    recipient: &BatchRecipient,
+    sdp_payment_id: Option<&str>,
+    tx_hash: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    sqlx::query(
+        r#"
+        UPDATE batch_recipients
+           SET status = 'SUBMITTED',
+               sdp_payment_id = COALESCE($2, sdp_payment_id),
+               tx_hash = COALESCE($3, tx_hash),
+               attempt_count = attempt_count + 1,
+               last_error = NULL,
+               locked_at = NULL,
+               locked_by = NULL,
+               updated_at = NOW()
+         WHERE id = $1
+        "#,
+    )
+    .bind(recipient.id)
+    .bind(sdp_payment_id)
+    .bind(tx_hash)
+    .execute(&mut *tx)
+    .await?;
+
+    // Counter and row move together, so a crash here cannot leave the batch
+    // claiming more successes than it has.
+    sqlx::query(
+        r#"
+        UPDATE payout_batches
+           SET succeeded_count = succeeded_count + 1,
+               updated_at = NOW()
+         WHERE id = $1
+        "#,
+    )
+    .bind(recipient.batch_id)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await
+}
+
+/// Releases the lease and increments the attempt so the row is picked up again.
+async fn mark_retry(
+    pool: &PgPool,
+    recipient: &BatchRecipient,
+    error: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        UPDATE batch_recipients
+           SET attempt_count = attempt_count + 1,
+               last_error = $2,
+               locked_at = NULL,
+               locked_by = NULL,
+               updated_at = NOW()
+         WHERE id = $1
+        "#,
+    )
+    .bind(recipient.id)
+    .bind(error)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn mark_failed(
+    pool: &PgPool,
+    recipient: &BatchRecipient,
+    error: &str,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    sqlx::query(
+        r#"
+        UPDATE batch_recipients
+           SET status = 'FAILED',
+               attempt_count = attempt_count + 1,
+               last_error = $2,
+               locked_at = NULL,
+               locked_by = NULL,
+               updated_at = NOW()
+         WHERE id = $1
+        "#,
+    )
+    .bind(recipient.id)
+    .bind(error)
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        r#"
+        UPDATE payout_batches
+           SET failed_count = failed_count + 1,
+               updated_at = NOW()
+         WHERE id = $1
+        "#,
+    )
+    .bind(recipient.batch_id)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await
+}
+
+/// Settles a batch's terminal status once no PENDING recipients remain.
+///
+/// Derived from the recipient rows rather than the denormalised counters, so a
+/// counter that drifted cannot strand a finished batch in PROCESSING.
+async fn finalize_batch(pool: &PgPool, batch_id: Uuid) -> Result<(), sqlx::Error> {
+    let result = sqlx::query(
+        r#"
+        WITH tally AS (
+            SELECT COUNT(*) FILTER (WHERE status = 'PENDING')  AS pending,
+                   COUNT(*) FILTER (WHERE status = 'FAILED')   AS failed,
+                   COUNT(*)                                    AS total
+              FROM batch_recipients
+             WHERE batch_id = $1
+        )
+        UPDATE payout_batches b
+           SET status = CASE
+                            WHEN tally.failed = 0            THEN 'COMPLETED'
+                            WHEN tally.failed = tally.total  THEN 'FAILED'
+                            ELSE 'PARTIALLY_FAILED'
+                        END,
+               completed_at = NOW(),
+               updated_at = NOW()
+          FROM tally
+         WHERE b.id = $1
+           AND tally.pending = 0
+           AND b.status = 'PROCESSING'
+        "#,
+    )
+    .bind(batch_id)
+    .execute(pool)
+    .await?;
+
+    if result.rows_affected() > 0 {
+        tracing::info!(batch_id = %batch_id, "Payout batch finished");
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn log_dispatch(
+    pool: &PgPool,
+    batch_id: Uuid,
+    recipient_id: Option<Uuid>,
+    attempt: i32,
+    event: &str,
+    sdp_response_code: Option<&str>,
+    detail: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO dispatch_logs
+            (batch_id, recipient_id, attempt, event, sdp_response_code, detail)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(batch_id)
+    .bind(recipient_id)
+    .bind(attempt)
+    .bind(event)
+    .bind(sdp_response_code)
+    .bind(detail)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idempotency_key_is_stable_across_retries() {
+        let id = Uuid::new_v4();
+        // The key must not vary with attempt number — that is what stops a
+        // retry from being paid as a second disbursement.
+        assert_eq!(idempotency_key_for(id), idempotency_key_for(id));
+        assert!(idempotency_key_for(id).contains(&id.to_string()));
+    }
+
+    #[test]
+    fn idempotency_keys_differ_between_recipients() {
+        assert_ne!(
+            idempotency_key_for(Uuid::new_v4()),
+            idempotency_key_for(Uuid::new_v4())
+        );
+    }
+
+    #[test]
+    fn config_defaults_are_sensible() {
+        let config = DisbursementWorkerConfig {
+            poll_interval: Duration::from_secs(DEFAULT_POLL_INTERVAL_SECS),
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            claim_size: DEFAULT_CLAIM_SIZE,
+            lease_timeout_secs: DEFAULT_LEASE_TIMEOUT_SECS,
+            sdp_base_url: "https://sdp.example.org".into(),
+            sdp_api_token: None,
+            worker_id: "test-worker".into(),
+        };
+
+        assert!(config.max_attempts >= 1, "a row must get at least one attempt");
+        assert!(config.claim_size > 0);
+        // The lease has to outlast a full claim of sequential submissions, or
+        // workers reclaim rows that are still legitimately in flight.
+        assert!(config.lease_timeout_secs > config.poll_interval.as_secs() as i64);
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod allbridge;
+pub mod disbursement_worker;
 pub mod notifications;
 pub mod stellar;
 pub mod sweep_worker;


### PR DESCRIPTION
Closes #554

> **Stacked on #629 (BE-555).** This branch contains the schema commit it depends on, so the diff shows both. Merge #629 first and this reduces to the worker alone.

Drains `payout_batches` asynchronously so an HTTP request never blocks on thousands of sequential SDP submissions.

## Why the database is the queue

The issue suggests a DB-backed task list *or* Redis streams. I went with the database, for one reason: **the payout rows and the queue state have to move together.**

With Redis the job and the row it describes live in separate systems, and a crash between *"SDP accepted the payment"* and *"Redis acked the job"* leaves them disagreeing — which for a payout system means paying twice or not at all. `SELECT ... FOR UPDATE SKIP LOCKED` gives the same competing-consumer semantics with the claim in the same transaction as the state it guards, and adds no new infrastructure to operate.

## Delivery semantics

At-least-once, made safe by idempotency rather than by pretending to be exactly-once:

- Batches **and** recipients are claimed with `SKIP LOCKED`, so N replicas never hand the same row to SDP concurrently.
- Each submission carries an idempotency key derived from **the recipient row id, not the attempt number** — every retry reuses the same key, so SDP deduplicates instead of paying again.

Failure classification is where the money is:

| Response | Treated as | Why |
|---|---|---|
| Network error | Retryable | No way to know whether SDP saw it — the idempotency key is what makes retrying safe |
| 4xx (except 408/429) | **Permanent** | A bad address or malformed amount is rejected identically forever; retrying only burns attempts |
| 408 / 429 / 5xx | Retryable | Transient |
| 2xx, unparseable body | **Submitted** | SDP accepted it. Failing here would risk a double payment on retry |

## Failure isolation and liveness

- A recipient that exhausts `max_attempts` is marked `FAILED` and left alone — **one dead recipient must not strand the rest of the batch.** The batch settles as `COMPLETED`, `PARTIALLY_FAILED` or `FAILED` on the tally.
- `finalize_batch` derives that terminal status from the **recipient rows**, not the denormalised counters, so a counter that drifted can't leave a finished batch stuck in `PROCESSING`.
- `reclaim_stale_leases` releases claims held by workers that died mid-dispatch. Without it a crashed worker's rows stay locked forever and the batch never completes. `attempt_count` is deliberately **not** reset — a row that keeps killing its worker should still exhaust its retries rather than loop indefinitely.
- Counter updates are committed in the same transaction as the row status they describe, so a crash can't leave a batch claiming more successes than it has.

## Sequential submission

As the issue requires — and independently worth doing: SDP rate-limits per account, and parallel submissions from one source account contend on the Stellar sequence number.

## Also in this change

- `PayoutBatch` / `BatchRecipient` / `DispatchLog` models in `db/models.rs`
- Module registered in `services/mod.rs`, worker spawned in `main.rs` alongside the existing sweep and notification workers
- Without `SDP_API_TOKEN` the worker runs in **dry-run mode**, exercising the full state machine without moving money

Config via env: `DISBURSEMENT_POLL_INTERVAL_SECS`, `DISBURSEMENT_MAX_ATTEMPTS`, `DISBURSEMENT_CLAIM_SIZE`, `DISBURSEMENT_LEASE_TIMEOUT_SECS`, `SDP_BASE_URL`, `SDP_API_TOKEN`.

## Acceptance criteria

- [x] Process payout items — claim/dispatch/settle loop over `batch_recipients`
- [x] Submit disbursements sequentially to SDP — one at a time within a batch
- [x] DB-backed task list tracking job states — `payout_batches.status`, `batch_recipients.status`, plus the `dispatch_logs` audit trail

## A note on file placement

The issue lists `backend/src/services/sweep_worker.rs`. I put this in a new `services/disbursement_worker.rs` instead — `sweep_worker` is the auto-earn idle-balance sweeper (BE-029/BE-051) and a bulk payout queue shares none of its logic or config. It also keeps this from colliding with #547, which does legitimately belong in `sweep_worker.rs`. Happy to move it if you'd rather keep the file list literal.

## Verification

Per the repo's existing pattern I've followed `sweep_worker`/`notifications` for config, spawning and tracing. I have **not** run `cargo build` or the test suite here, and the SQL has not been executed against a live Postgres — the `FOR UPDATE SKIP LOCKED` claim queries in particular deserve a real run before merging. Unit tests cover the idempotency key invariants and config sanity; the DB-dependent paths would need an integration test with a live database, which I'd be glad to add if you point me at the preferred harness.
