### PR TITLE
feat(be-547): add hourly yield compounding checkpoint worker

### DIFF
--- a/backend/src/db/yield.rs
+++ b/backend/src/db/yield.rs
@@ -179,6 +179,27 @@ pub async fn get_current_yield_rate(pool: &PgPool) -> Result<Option<i32>, sqlx::
     Ok(rate)
 }
 
+/// BE-547: age of the most recent APY checkpoint, in seconds.
+///
+/// `None` when no checkpoint has ever been recorded. Used by the hourly
+/// checkpoint worker to decide whether a tick is actually due: `tokio::interval`
+/// restarts its clock on process start, so without this a crash-looping or
+/// frequently-redeployed process would write a checkpoint on every boot.
+pub async fn seconds_since_last_yield_rate(pool: &PgPool) -> Result<Option<i64>, sqlx::Error> {
+    let age: Option<f64> = sqlx::query_scalar(
+        r#"
+        SELECT EXTRACT(EPOCH FROM (NOW() - created_at))
+          FROM yield_rates_history
+         ORDER BY created_at DESC
+         LIMIT 1
+        "#,
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(age.map(|secs| secs as i64))
+}
+
 /// Read whether the user has auto-earn (auto-sweep) enabled.
 pub async fn get_auto_earn_enabled(pool: &PgPool, user_id: Uuid) -> Result<bool, sqlx::Error> {
     let enabled = sqlx::query_scalar(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -297,6 +297,14 @@ async fn main() {
         services::sweep_worker::run(sweep_pool, sweep_config).await;
     });
 
+    // BE-547: Hourly APY checkpoints into yield_rates_history, so the series
+    // every yield estimate is priced against has a guaranteed cadence.
+    let checkpoint_pool = pool.clone();
+    let checkpoint_config = services::sweep_worker::YieldCheckpointConfig::from_env();
+    tokio::spawn(async move {
+        services::sweep_worker::run_yield_checkpoints(checkpoint_pool, checkpoint_config).await;
+    });
+
     // BE-032: Daily / weekly yield report push notifications.
     let notification_pool = pool.clone();
     let notification_config = services::notifications::NotificationSchedulerConfig::from_env();

--- a/backend/src/services/sweep_worker.rs
+++ b/backend/src/services/sweep_worker.rs
@@ -2,7 +2,10 @@ use sqlx::PgPool;
 use std::time::Duration;
 use uuid::Uuid;
 
-use crate::db::r#yield::{list_auto_sweep_candidates, process_internal_sweep_deposit};
+use crate::db::r#yield::{
+    get_current_yield_rate, list_auto_sweep_candidates, log_yield_rate_update,
+    process_internal_sweep_deposit, seconds_since_last_yield_rate,
+};
 use crate::services::stellar::StellarClient;
 
 const DEFAULT_SWEEP_INTERVAL_SECS: u64 = 300;
@@ -210,9 +213,201 @@ fn sign_envelope(
     Ok(signed.to_string())
 }
 
+// ─── BE-547: hourly yield compounding checkpoints ────────────────────────────
+//
+// `yield_rates_history` is the series every APY figure in the product is
+// derived from: `estimate_accrued_yield` prices a user's earning balance
+// against the prevailing rate, and the metrics endpoint reports the current
+// APY from it. Until now nothing wrote to it on a schedule — rates were only
+// recorded when something else happened to call `log_yield_rate_update`, so the
+// series had gaps and "APY over time" could not be answered at all.
+//
+// This worker closes that: it reads the vault's parameters on a fixed interval
+// and records a checkpoint, giving the series a guaranteed cadence.
+
+const DEFAULT_CHECKPOINT_INTERVAL_SECS: u64 = 3_600;
+/// Fallback APY (basis points) when the vault cannot be reached and no prior
+/// checkpoint exists. Matches `yield_calc::DEFAULT_APY_BPS`.
+const FALLBACK_APY_BPS: i32 = 500;
+/// Tolerance when deciding whether a checkpoint is due.
+///
+/// Timer ticks drift by a few milliseconds and `NOW()` is evaluated on the
+/// database, so an exact `age >= interval` comparison would skip roughly every
+/// other hour. 60s of slack keeps the cadence honest without allowing a second
+/// checkpoint inside the same window.
+const CHECKPOINT_DUE_SLACK_SECS: i64 = 60;
+
+pub struct YieldCheckpointConfig {
+    pub interval: Duration,
+    /// Soroban RPC endpoint used to read vault parameters.
+    pub stellar_rpc_url: String,
+    /// YieldVault contract to read the rate from. Without it the worker falls
+    /// back to the last recorded rate.
+    pub yield_vault_contract_id: Option<String>,
+}
+
+impl YieldCheckpointConfig {
+    pub fn from_env() -> Self {
+        let interval_secs = std::env::var("YIELD_CHECKPOINT_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_CHECKPOINT_INTERVAL_SECS);
+        let stellar_rpc_url = std::env::var("STELLAR_RPC_URL")
+            .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".into());
+        let yield_vault_contract_id = std::env::var("YIELD_VAULT_CONTRACT_ID").ok();
+
+        Self {
+            interval: Duration::from_secs(interval_secs),
+            stellar_rpc_url,
+            yield_vault_contract_id,
+        }
+    }
+}
+
+/// BE-547: records an APY checkpoint into `yield_rates_history` on a fixed
+/// interval. Runs until the process exits.
+pub async fn run_yield_checkpoints(pool: PgPool, config: YieldCheckpointConfig) {
+    tracing::info!(
+        "Starting yield checkpoint worker (interval={:?}, vault={:?})",
+        config.interval,
+        config.yield_vault_contract_id
+    );
+
+    let stellar = StellarClient::new(config.stellar_rpc_url.clone());
+    let mut interval = tokio::time::interval(config.interval);
+
+    loop {
+        interval.tick().await;
+
+        if let Err(err) = checkpoint_once(
+            &pool,
+            &stellar,
+            config.yield_vault_contract_id.as_deref(),
+            config.interval.as_secs() as i64,
+        )
+        .await
+        {
+            // Never propagate: a failed checkpoint must not kill the loop, or
+            // one bad RPC response ends the series until the next deploy.
+            tracing::error!("Yield checkpoint cycle failed: {err:?}");
+        }
+    }
+}
+
+/// One checkpoint cycle. Separated from the loop so it can be driven directly.
+async fn checkpoint_once(
+    pool: &PgPool,
+    stellar: &StellarClient,
+    contract_id: Option<&str>,
+    interval_secs: i64,
+) -> Result<(), sqlx::Error> {
+    if !is_checkpoint_due(pool, interval_secs).await? {
+        tracing::debug!("Yield checkpoint: not due yet, skipping");
+        return Ok(());
+    }
+
+    let previous = get_current_yield_rate(pool).await?;
+    let apy_bps = read_vault_apy_bps(stellar, contract_id)
+        .await
+        .unwrap_or_else(|err| {
+            // Carrying the last known rate forward is the right failure mode:
+            // it keeps the series continuous, and a gap would be read by
+            // downstream consumers as "no yield" rather than "unknown".
+            tracing::warn!(
+                error = %err,
+                "Could not read vault APY; carrying the previous checkpoint forward"
+            );
+            previous.unwrap_or(FALLBACK_APY_BPS)
+        });
+
+    log_yield_rate_update(pool, apy_bps).await?;
+
+    tracing::info!(
+        apy_bps,
+        previous_bps = ?previous,
+        "Recorded hourly yield checkpoint"
+    );
+    Ok(())
+}
+
+/// Whether enough time has passed since the last checkpoint.
+///
+/// `tokio::interval` fires immediately on its first tick and restarts its clock
+/// on process start, so without this guard a crash-looping or frequently
+/// redeployed service would write a checkpoint on every boot and corrupt the
+/// hourly cadence the series is supposed to guarantee.
+async fn is_checkpoint_due(pool: &PgPool, interval_secs: i64) -> Result<bool, sqlx::Error> {
+    match seconds_since_last_yield_rate(pool).await? {
+        // No history at all — seed the series.
+        None => Ok(true),
+        Some(age) => Ok(age >= interval_secs - CHECKPOINT_DUE_SLACK_SECS),
+    }
+}
+
+/// Reads the current APY (basis points) from the YieldVault contract.
+///
+/// Simulation rather than submission: reading a parameter must not cost a fee
+/// or consume a sequence number.
+async fn read_vault_apy_bps(
+    stellar: &StellarClient,
+    contract_id: Option<&str>,
+) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
+    let contract_id = contract_id.ok_or("YIELD_VAULT_CONTRACT_ID not set")?;
+
+    let envelope = serde_json::json!({
+        "contract_id": contract_id,
+        "function": "current_apy_bps",
+        "args": []
+    })
+    .to_string();
+
+    let sim = stellar.simulate_transaction(&envelope).await?;
+    if let Some(err) = sim.error {
+        return Err(format!("Vault APY simulation failed: {err}").into());
+    }
+
+    let raw = sim
+        .results
+        .as_ref()
+        .and_then(|results| results.first())
+        .map(|result| result.xdr.as_str())
+        .ok_or("Vault APY simulation returned no result")?;
+
+    let apy_bps: i32 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("Vault returned an unparseable APY value: {raw}"))?;
+
+    // A negative or absurd rate means the vault returned something unexpected;
+    // recording it would poison every yield estimate derived from the series.
+    if !(0..=100_000).contains(&apy_bps) {
+        return Err(format!("Vault returned an out-of-range APY: {apy_bps} bps").into());
+    }
+
+    Ok(apy_bps)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn checkpoint_config_defaults_to_hourly() {
+        let config = YieldCheckpointConfig {
+            interval: Duration::from_secs(DEFAULT_CHECKPOINT_INTERVAL_SECS),
+            stellar_rpc_url: "https://soroban-testnet.stellar.org".into(),
+            yield_vault_contract_id: None,
+        };
+        assert_eq!(config.interval.as_secs(), 3_600);
+        assert!(config.yield_vault_contract_id.is_none());
+    }
+
+    #[test]
+    fn checkpoint_slack_is_smaller_than_the_interval() {
+        // If the slack ever met or exceeded the interval, every tick would be
+        // "due" and the guard against double-writing on restart would be gone.
+        assert!(CHECKPOINT_DUE_SLACK_SECS < DEFAULT_CHECKPOINT_INTERVAL_SECS as i64);
+    }
 
     #[test]
     fn config_defaults_are_sensible() {


### PR DESCRIPTION
Closes #547

## Problem

`yield_rates_history` is the series **every APY figure in the product is derived from** — `estimate_accrued_yield` prices a user's earning balance against the prevailing rate, and the yield endpoints report the current APY from it.

Nothing wrote to it on a schedule. Rates were only recorded when something else happened to call `log_yield_rate_update`, so the series had arbitrary gaps and *"APY over time"* could not be answered at all.

## Approach

`run_yield_checkpoints` — a `tokio::interval` worker that reads the vault's parameters and records a checkpoint, giving the series a guaranteed cadence. Configurable via `YIELD_CHECKPOINT_INTERVAL_SECS`, hourly by default.

## Not writing a checkpoint on every boot

This is the part worth reviewing. `tokio::interval` fires **immediately** on its first tick and restarts its clock on process start. A crash-looping or frequently redeployed service would therefore write a checkpoint on every boot — destroying the exact hourly cadence the series is supposed to guarantee.

`is_checkpoint_due` asks the *database* how old the last checkpoint actually is, so the cadence survives restarts. It allows 60s of slack because timer ticks drift and `NOW()` is evaluated on the database — an exact `age >= interval` comparison would skip roughly every other hour.

A test asserts the slack stays smaller than the interval: if it ever met it, every tick would be "due" and the guard would silently be gone.

## Failure handling

- **Simulation, not submission.** Reading a parameter must not cost a fee or consume a sequence number.
- **A failed vault read carries the previous rate forward** rather than skipping the checkpoint. A gap would be read by downstream consumers as *"no yield"* rather than *"unknown"* — worse than a slightly stale figure. With no prior checkpoint it falls back to the same 500 bps default `yield_calc` already uses.
- **An out-of-range APY is rejected, not recorded.** A negative or absurd rate means the vault returned something unexpected, and storing it would poison every yield estimate derived from the series afterwards.
- **Errors never propagate out of the loop**, so one bad RPC response can't end the series until the next deploy.

## Acceptance criteria

- [x] Read vault parameters periodically — `read_vault_apy_bps` via Soroban simulation on a configurable interval
- [x] Insert record in `yield_rates_history` — through the existing `log_yield_rate_update`
- [x] Standard tokio intervals — `tokio::time::interval`, matching `sweep_worker` and `notifications`

## Also in this change

- `db::yield::seconds_since_last_yield_rate` for the due check
- Worker spawned in `main.rs` alongside the existing sweep and notification workers

Placed in `sweep_worker.rs` as the issue specifies — it's a recurring vault-reading worker, which is what that module already holds.

## Verification

I have **not** run `cargo build` or the test suite, and the new SQL hasn't been executed against a live Postgres. Unit tests cover the config defaults and the slack-vs-interval invariant; `checkpoint_once` is factored out of the loop specifically so it can be driven directly from an integration test with a live database — glad to add one if you point me at the preferred harness.

One thing to confirm: `read_vault_apy_bps` calls `current_apy_bps` on the vault and parses the simulation result as an integer. That follows the same simplified envelope/simulation shape as the existing `build_deposit_envelope` in this file, so if the real contract exposes the rate under a different name or encoding, that call is the line to correct.
