### PR TITLE
feat(be-548): add GET /api/yield/metrics endpoint

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -65,6 +65,7 @@ pub fn yield_routes(pool: sqlx::PgPool) -> Router {
 pub fn yield_routes_with_state(state: r#yield::YieldState) -> Router {
     Router::new()
         .route("/balance", get(r#yield::get_balance))
+        .route("/metrics", get(r#yield::get_metrics))
         .route("/history", get(r#yield::get_history))
         .route("/deposit", post(r#yield::deposit))
         .route("/withdraw", post(r#yield::withdraw))

--- a/backend/src/api/yield.rs
+++ b/backend/src/api/yield.rs
@@ -254,6 +254,192 @@ pub async fn get_balance(State(state): State<YieldState>, auth: AuthUser) -> imp
     .into_response()
 }
 
+// ── BE-548 — GET /api/yield/metrics ───────────────────────────────────────
+
+/// Micro-units per whole currency unit. Balances are stored scaled by this.
+const MICRO_UNITS_PER_UNIT: f64 = 1_000_000.0;
+
+/// Fallback USD→NGN rate when `USD_NGN_RATE` is unset.
+///
+/// Deliberately a config value rather than a hard-coded constant used blindly:
+/// NGN moves too much for a compiled-in number to stay honest, and the response
+/// echoes back the rate it used so a client can tell a stale figure from a
+/// fresh one. A live FX feed is the proper long-term answer — see the note on
+/// `fx_rate_source` below.
+const DEFAULT_USD_NGN_RATE: f64 = 1600.0;
+
+fn usd_ngn_rate() -> f64 {
+    std::env::var("USD_NGN_RATE")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        // A zero or negative rate would silently zero out every NGN figure, so
+        // treat it as unset rather than trusting it.
+        .filter(|rate| *rate > 0.0)
+        .unwrap_or(DEFAULT_USD_NGN_RATE)
+}
+
+/// Converts a micro-unit balance to whole units.
+fn to_units(micro: i64) -> f64 {
+    micro as f64 / MICRO_UNITS_PER_UNIT
+}
+
+#[derive(Serialize)]
+pub struct UserYieldMetrics {
+    pub available_balance: i64,
+    pub earning_balance: i64,
+    /// Live off-chain estimate since the last sync (micro-units).
+    pub accrued_interest: i64,
+    pub total_earning_balance: i64,
+    /// Lifetime totals from `yield_transactions` (micro-units).
+    pub total_deposited: i64,
+    pub total_withdrawn: i64,
+    /// Interest already credited on-chain, as distinct from `accrued_interest`,
+    /// which is the live estimate for the current period.
+    pub total_earned: i64,
+    pub transaction_count: i64,
+    pub auto_earn_enabled: bool,
+}
+
+#[derive(Serialize)]
+pub struct PlatformYieldMetrics {
+    /// Total value locked, in micro-units.
+    pub tvl: i64,
+    pub tvl_usd: f64,
+    pub tvl_ngn: f64,
+    /// Idle balances not yet earning, in micro-units.
+    pub total_available: i64,
+    pub active_accounts: i64,
+    pub auto_earn_accounts: i64,
+}
+
+#[derive(Serialize)]
+pub struct YieldMetricsResponse {
+    /// Current APY as a percentage (e.g. 5.0 for 5%).
+    pub apy: f64,
+    /// Same rate in basis points, for clients that would rather not round-trip
+    /// through a float.
+    pub apy_bps: i32,
+    pub user: UserYieldMetrics,
+    pub platform: PlatformYieldMetrics,
+    /// The USD→NGN rate applied to `tvl_ngn`, echoed so a client can tell which
+    /// rate produced the figure.
+    pub usd_ngn_rate: f64,
+    /// Where that rate came from: `"config"` or `"default"`. A client showing
+    /// Naira to a user needs to know when it is displaying a compiled-in guess.
+    pub fx_rate_source: &'static str,
+    pub generated_at: String,
+}
+
+/// BE-548: `GET /api/yield/metrics`
+///
+/// One call returning both the caller's yield position and platform-wide
+/// totals. Built as a single endpoint rather than leaving clients to fan out
+/// across `/balance` plus separate aggregate calls: the dashboard renders these
+/// numbers side by side, and separate requests would let the user's balance and
+/// the TVL it is a share of come from different moments.
+pub async fn get_metrics(State(state): State<YieldState>, auth: AuthUser) -> impl IntoResponse {
+    let pool = &state.pool;
+
+    let balance = match crate::db::r#yield::get_or_create_yield_balance(pool, auth.id).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!("yield metrics balance fetch error: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to retrieve yield balance" })),
+            )
+                .into_response();
+        }
+    };
+
+    let apy_bps = match state.load_yield_rate().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("yield metrics rate fetch error: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to retrieve yield rate" })),
+            )
+                .into_response();
+        }
+    };
+
+    let user_totals = match crate::db::r#yield::get_user_yield_totals(pool, auth.id).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!("yield metrics user totals error: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to retrieve user yield totals" })),
+            )
+                .into_response();
+        }
+    };
+
+    let platform_totals = match crate::db::r#yield::get_platform_yield_totals(pool).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!("yield metrics platform totals error: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to retrieve platform yield totals" })),
+            )
+                .into_response();
+        }
+    };
+
+    let auto_earn_enabled = match crate::db::r#yield::get_auto_earn_enabled(pool, auth.id).await {
+        Ok(enabled) => enabled,
+        Err(e) => {
+            tracing::error!("yield metrics auto-earn fetch error: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to retrieve auto-earn preference" })),
+            )
+                .into_response();
+        }
+    };
+
+    let estimate = yield_calc::estimate_for_balance(&balance, Some(apy_bps), Utc::now());
+
+    let fx_rate_source = if std::env::var("USD_NGN_RATE").is_ok() {
+        "config"
+    } else {
+        "default"
+    };
+    let rate = usd_ngn_rate();
+    // Balances are held in a USD stablecoin, so units are already USD.
+    let tvl_usd = to_units(platform_totals.tvl);
+
+    Json(YieldMetricsResponse {
+        apy: apy_bps as f64 / 100.0,
+        apy_bps,
+        user: UserYieldMetrics {
+            available_balance: balance.available_balance,
+            earning_balance: balance.earning_balance,
+            accrued_interest: estimate.accrued_interest,
+            total_earning_balance: estimate.total_earning_balance,
+            total_deposited: user_totals.total_deposited,
+            total_withdrawn: user_totals.total_withdrawn,
+            total_earned: user_totals.total_earned,
+            transaction_count: user_totals.transaction_count,
+            auto_earn_enabled,
+        },
+        platform: PlatformYieldMetrics {
+            tvl: platform_totals.tvl,
+            tvl_usd,
+            tvl_ngn: tvl_usd * rate,
+            total_available: platform_totals.total_available,
+            active_accounts: platform_totals.active_accounts,
+            auto_earn_accounts: platform_totals.auto_earn_accounts,
+        },
+        usd_ngn_rate: rate,
+        fx_rate_source,
+        generated_at: Utc::now().to_rfc3339(),
+    })
+    .into_response()
+}
+
 // ── #374 — GET /api/yield/history ─────────────────────────────────────────
 
 /// Friendly categories for yield transactions logged in history.

--- a/backend/src/db/yield.rs
+++ b/backend/src/db/yield.rs
@@ -179,6 +179,86 @@ pub async fn get_current_yield_rate(pool: &PgPool) -> Result<Option<i32>, sqlx::
     Ok(rate)
 }
 
+/// BE-548: platform-wide yield aggregates for the metrics endpoint.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PlatformYieldTotals {
+    /// Sum of every user's earning balance — total value locked, in micro-units.
+    pub tvl: i64,
+    /// Sum of every user's idle available balance, in micro-units.
+    pub total_available: i64,
+    /// Users with a non-zero earning balance.
+    pub active_accounts: i64,
+    /// Users with auto-earn switched on.
+    pub auto_earn_accounts: i64,
+}
+
+/// BE-548: one pass over `user_yield_balances` for the platform totals.
+///
+/// Deliberately a single query rather than four: separate statements would each
+/// see a different snapshot, so a deposit landing mid-read could produce a TVL
+/// that does not match the account count reported beside it.
+pub async fn get_platform_yield_totals(pool: &PgPool) -> Result<PlatformYieldTotals, sqlx::Error> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            COALESCE(SUM(b.earning_balance), 0)::BIGINT   AS tvl,
+            COALESCE(SUM(b.available_balance), 0)::BIGINT AS total_available,
+            COUNT(*) FILTER (WHERE b.earning_balance > 0) AS active_accounts,
+            COUNT(*) FILTER (WHERE u.auto_earn_enabled)   AS auto_earn_accounts
+          FROM user_yield_balances b
+          JOIN users u ON u.id = b.user_id
+        "#,
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(PlatformYieldTotals {
+        tvl: row.get("tvl"),
+        total_available: row.get("total_available"),
+        active_accounts: row.get("active_accounts"),
+        auto_earn_accounts: row.get("auto_earn_accounts"),
+    })
+}
+
+/// BE-548: a single user's lifetime yield totals, in micro-units.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UserYieldTotals {
+    pub total_deposited: i64,
+    pub total_withdrawn: i64,
+    /// Interest already credited on-chain, as distinct from the live off-chain
+    /// estimate the balance endpoint reports.
+    pub total_earned: i64,
+    pub transaction_count: i64,
+}
+
+/// BE-548: aggregates a user's `yield_transactions` by type in one pass.
+pub async fn get_user_yield_totals(
+    pool: &PgPool,
+    user_id: Uuid,
+) -> Result<UserYieldTotals, sqlx::Error> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            COALESCE(SUM(amount) FILTER (WHERE type = 'DEPOSIT'), 0)::BIGINT  AS total_deposited,
+            COALESCE(SUM(amount) FILTER (WHERE type = 'WITHDRAW'), 0)::BIGINT AS total_withdrawn,
+            COALESCE(SUM(amount) FILTER (WHERE type = 'EARNED'), 0)::BIGINT   AS total_earned,
+            COUNT(*)                                                          AS transaction_count
+          FROM yield_transactions
+         WHERE user_id = $1
+        "#,
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(UserYieldTotals {
+        total_deposited: row.get("total_deposited"),
+        total_withdrawn: row.get("total_withdrawn"),
+        total_earned: row.get("total_earned"),
+        transaction_count: row.get("transaction_count"),
+    })
+}
+
 /// Read whether the user has auto-earn (auto-sweep) enabled.
 pub async fn get_auto_earn_enabled(pool: &PgPool, user_id: Uuid) -> Result<bool, sqlx::Error> {
     let enabled = sqlx::query_scalar(


### PR DESCRIPTION
Closes #548

Implements `GET /api/yield/metrics` — the caller's yield position and platform-wide totals in one call.

## Response shape

```json
{
  "apy": 5.0,
  "apy_bps": 500,
  "user": {
    "available_balance": 250000,
    "earning_balance": 1000000,
    "accrued_interest": 137,
    "total_earning_balance": 1000137,
    "total_deposited": 1200000,
    "total_withdrawn": 200000,
    "total_earned": 4310,
    "transaction_count": 7,
    "auto_earn_enabled": true
  },
  "platform": {
    "tvl": 984320000,
    "tvl_usd": 984.32,
    "tvl_ngn": 1574912.0,
    "total_available": 120450000,
    "active_accounts": 143,
    "auto_earn_accounts": 96
  },
  "usd_ngn_rate": 1600.0,
  "fx_rate_source": "default",
  "generated_at": "2026-07-25T21:04:11.482Z"
}
```

## One endpoint, not several

Built as a single endpoint rather than leaving clients to fan out across `/balance` plus separate aggregate calls. The dashboard renders these numbers side by side, and separate requests would let a user's balance and the TVL it's a share of come from **different moments**.

The same reasoning drives the two new DB helpers — `get_platform_yield_totals` and `get_user_yield_totals` are each **one query with `FILTER` clauses** rather than several statements. Separate statements would each see a different snapshot, so a deposit landing mid-read could produce a TVL that doesn't match the account count reported beside it.

## Currency conversion — worth a look

Balances are held in a USD stablecoin, so USD needs only scaling out of micro-units. **NGN needs a rate, and there isn't one anywhere in the backend today.**

Rather than hard-code one and pretend it's authoritative:

- the rate comes from `USD_NGN_RATE`, with a documented fallback
- the response echoes back **both** the rate applied and `fx_rate_source` (`"config"` or `"default"`)
- a zero or negative configured rate is treated as unset, since trusting it would silently zero out every NGN figure

A client showing Naira to a user needs to be able to tell when it's displaying a compiled-in guess. A live FX feed is the proper long-term answer — `fx_rate_source` is what makes the current limitation visible rather than invisible. Happy to wire it to a real feed if there's a preferred provider.

## Acceptance criteria

- [x] `GET /api/yield/metrics` returning yield stats
- [x] User-specific metrics — balances, live accrued interest, lifetime deposited/withdrawn/earned, transaction count, auto-earn flag
- [x] Overall TVL in USD/Naira — `tvl_usd` and `tvl_ngn`, plus raw micro-units for clients that want to do their own formatting
- [x] Returns correct balance values — reuses `get_or_create_yield_balance` and `yield_calc::estimate_for_balance`, the same primitives `/balance` already returns, so the two endpoints can't drift

`apy` is returned in both percent and basis points so clients that would rather not round-trip through a float don't have to. `total_earned` (credited on-chain) is kept distinct from `accrued_interest` (live estimate for the current period) — conflating them would double-count.

Auth follows the existing `/balance` pattern via the `AuthUser` extractor, and the rate is read through the existing Redis-backed `load_yield_rate`, so this adds no new cache paths.

## Verification

I have **not** run `cargo build` or the test suite, and the new SQL hasn't been executed against Postgres. The two aggregate queries use `COUNT(*) FILTER` / `SUM(...) FILTER` with explicit `::BIGINT` casts to match the `i64` bindings — that's the part I'd most want confirmed against a real database before merging, since a type mismatch there would surface at runtime rather than compile time.

`backend/tests/yield_api_tests.rs` looks like the natural home for coverage of this endpoint; glad to add cases there if you tell me how the suite provisions its database.
