### PR TITLE
fix(indexer): parse UserRegistered events and sync user table entries

### DIFF
--- a/backend/src/indexer/parser.rs
+++ b/backend/src/indexer/parser.rs
@@ -27,12 +27,30 @@ pub struct TokenSalvagedEvent {
     pub tx_hash: String,
 }
 
+/// BE-061: emitted when the yield vault compounds interest.
+pub struct YieldAccruedEvent {
+    pub added_yield: i64,
+    pub elapsed_ledgers: i64,
+    pub new_index: i64,
+    pub tx_hash: String,
+}
+
+/// #542: emitted by the user_registry contract's `register_user` when a
+/// Stellar address claims a Zaps username on-chain.
+pub struct UserRegisteredEvent {
+    pub address: String,
+    pub username: String,
+    pub tx_hash: String,
+}
+
 pub enum ZapsEvent {
     YieldDeposited(YieldDepositedEvent),
     YieldWithdrawn(YieldWithdrawnEvent),
     YieldRateUpdated(YieldRateUpdatedEvent),
+    YieldAccrued(YieldAccruedEvent),
     // 2. Add the new variant to the enum
     TokenSalvaged(TokenSalvagedEvent),
+    UserRegistered(UserRegisteredEvent),
     Unknown,
 }
 
@@ -112,6 +130,23 @@ pub fn parse_zaps_event(topic: &str, value: &Value) -> ZapsEvent {
             let tx_hash = extract_tx_hash(value);
 
             ZapsEvent::TokenSalvaged(TokenSalvagedEvent { salvager, token, recipient, amount, tx_hash })
+        }
+        "YieldAccrued" => {
+            let added_yield = find_nested_i64(value, "added_yield").unwrap_or_default();
+            let elapsed_ledgers = find_nested_i64(value, "elapsed_ledgers").unwrap_or_default();
+            let new_index = find_nested_i64(value, "new_index").unwrap_or_default();
+            let tx_hash = extract_tx_hash(value);
+
+            ZapsEvent::YieldAccrued(YieldAccruedEvent { added_yield, elapsed_ledgers, new_index, tx_hash })
+        }
+        // #542: address + username come straight off the UserRegistered event
+        // payload XDR (decoded to JSON upstream), same as every other event here.
+        "UserRegistered" => {
+            let address = find_nested_string(value, "address").unwrap_or_default();
+            let username = find_nested_string(value, "username").unwrap_or_default();
+            let tx_hash = extract_tx_hash(value);
+
+            ZapsEvent::UserRegistered(UserRegisteredEvent { address, username, tx_hash })
         }
         _ => ZapsEvent::Unknown,
     }

--- a/backend/src/indexer/worker.rs
+++ b/backend/src/indexer/worker.rs
@@ -4,7 +4,8 @@ use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::{env, error::Error, time::Duration};
 use uuid::Uuid;
 
-use super::parser::{parse_zaps_event, ZapsEvent, TokenSalvagedEvent};
+use super::parser::{parse_zaps_event, ZapsEvent, TokenSalvagedEvent, UserRegisteredEvent};
+use crate::api::r#yield::{invalidate_platform_yield_cache, YieldCache};
 use crate::db::r#yield::{process_yield_deposit_tx, process_yield_withdrawal_tx, log_yield_rate_update};
 
 const INDEXER_CURSOR_KEY: &str = "stellar_event_cursor";
@@ -60,65 +61,23 @@ pub async fn run(
                     next_cursor = cursor + 1;
                 }
 
-                // AC1 + AC2: Open one transaction; write all events AND the new
-                // checkpoint inside it so they commit or roll back atomically.
-                let mut tx = pool.begin().await?;
-
-                for event in &events {
-                    // Try to extract topic from event. Soroban RPC typically returns topics as an array of XDR strings, 
-                    // but since the existing code uses `find_nested_string`, we'll try to guess the event type 
-                    // or assume the topic is available in the payload somehow (e.g. decoded by a proxy or we check fields).
-                    // For now, we will use a heuristic: if it has "apy", it's YieldRateUpdated.
-                    // Otherwise we try extracting topic.
-                    
-                    let topic_hint = super::parser::find_nested_string(event, "topic_symbol")
-                        .or_else(|| super::parser::find_nested_string(event, "event_type"));
-                    
-                    let guessed_topic = if let Some(t) = topic_hint {
-                        t
-                    } else if super::parser::find_nested_i64(event, "apy").is_some() {
-                        "YieldRateUpdated".to_string()
-                    } else if super::parser::find_nested_string(event, "sender").is_some() {
-                        "SocialPaymentEvent".to_string()
-                    } else if let Some(t) = super::parser::find_nested_string(event, "type") {
-                        t // maybe type="DEPOSIT" etc.
-                    } else {
-                        "".to_string()
-                    };
-
-                    match parse_zaps_event(&guessed_topic, event) {
-                        ZapsEvent::YieldDeposited(e) => {
-                            let user_id = get_or_create_user_id(&e.address, &pool).await.unwrap_or_else(|_| Uuid::new_v4());
-                            if let Err(err) = process_yield_deposit_tx(&mut tx, user_id, e.amount, &e.tx_hash).await {
-                                tracing::warn!("Failed to process YieldDeposited event: {err}");
-                            }
+                // AC1 + AC2: process_event_batch_with_guard writes every event
+                // AND the new checkpoint inside one transaction, committing or
+                // rolling back atomically. (Previously this loop opened its own
+                // transaction, processed events through it, and then never
+                // called `.commit()` or persisted the cursor — every batch was
+                // silently discarded on the next poll's implicit rollback.
+                // Delegating to the already-tested guarded processor fixes
+                // that and gives UserRegistered/YieldAccrued handling for free.)
+                match process_event_batch_with_guard(&pool, &events, next_cursor).await {
+                    Ok(outcome) => {
+                        cursor = next_cursor;
+                        if outcome.platform_yield_dirty {
+                            invalidate_platform_yield_cache(cache.as_ref()).await;
                         }
-                        ZapsEvent::YieldWithdrawn(e) => {
-                            let user_id = get_or_create_user_id(&e.address, &pool).await.unwrap_or_else(|_| Uuid::new_v4());
-                            if let Err(err) = process_yield_withdrawal_tx(&mut tx, user_id, e.amount, &e.tx_hash).await {
-                                tracing::warn!("Failed to process YieldWithdrawn event: {err}");
-                            }
-                        }
-                        ZapsEvent::YieldRateUpdated(e) => {
-                            if let Err(err) = log_yield_rate_update(&pool, e.apy).await {
-                                tracing::warn!("Failed to process YieldRateUpdated event: {err}");
-                            }
-                         }
-
-                        ZapsEvent::TokenSalvaged(e) => {
-                            if let Err(err) = process_token_salvaged_event(e, &mut tx).await {
-                                tracing::warn!("Failed to process TokenSalvaged event: {err}");
-                            }
-                        }
-                        ZapsEvent::Unknown => {
-                            if let Some(payment_event) = extract_social_payment_event(event) {
-                                if let Err(err) =
-                                    process_social_payment_event(payment_event, &pool, &mut tx).await
-                                {
-                                    tracing::warn!("Failed to process Stellar payment event: {err}");
-                                }
-                            }
-                        }
+                    }
+                    Err(err) => {
+                        tracing::error!("Failed to process indexer event batch: {err}");
                     }
                 }
 
@@ -180,6 +139,10 @@ pub async fn process_event_batch_with_guard(
                         e.tx_hash
                     );
                     outcome.platform_yield_dirty = true;
+                }
+                // #542: sync a real on-chain username to the users table.
+                ZapsEvent::UserRegistered(e) => {
+                    process_user_registered_event(e, &mut tx).await?;
                 }
                 ZapsEvent::Unknown => {
                     if let Some(payment_event) = extract_social_payment_event(event) {
@@ -282,6 +245,9 @@ fn build_get_events_payload(start_ledger: i64, contract_id: Option<&str>) -> Val
         json!({ "topics": [[{ "type": "symbol", "value": "YieldRateUpdated" }]] }),
         // Add this new line:
         json!({ "topics": [[{ "type": "symbol", "value": "TokenSalvaged" }]] }),
+        json!({ "topics": [[{ "type": "symbol", "value": "YieldAccrued" }]] }),
+        // #542
+        json!({ "topics": [[{ "type": "symbol", "value": "UserRegistered" }]] }),
     ];
     // ... rest of the function remains exactly the same
 
@@ -413,29 +379,6 @@ fn find_nested_i64(value: &Value, key: &str) -> Option<i64> {
     }
 }
 
-async fn get_or_create_user_id(
-    address: &str,
-    pool: &PgPool,
-) -> Result<Uuid, Box<dyn std::error::Error + Send + Sync>> {
-    let username = slugify_address(address);
-    let row = sqlx::query(
-        r#"
-        INSERT INTO users (address, username, display_name)
-        VALUES ($1, $2, $3)
-        ON CONFLICT (address)
-        DO UPDATE SET username = COALESCE(users.username, EXCLUDED.username)
-        RETURNING id
-        "#,
-    )
-    .bind(address)
-    .bind(&username)
-    .bind(Some(&username))
-    .fetch_one(pool)
-    .await?;
-
-    Ok(row.get("id"))
-}
-
 async fn get_or_create_user_id_tx(
     tx: &mut Transaction<'_, Postgres>,
     address: &str,
@@ -509,6 +452,32 @@ pub async fn process_token_salvaged_event(
     Ok(())
 }
 
+/// #542: sync a real on-chain username registration to the `users` table.
+///
+/// Unlike `get_or_create_user_id_tx`'s slugified placeholder (used when an
+/// address is only known from a payment/yield event), this always overwrites
+/// `username` with the on-chain value — a `UserRegistered` event is the
+/// authoritative source, so it must supersede any placeholder.
+pub async fn process_user_registered_event(
+    event: UserRegisteredEvent,
+    tx: &mut Transaction<'_, Postgres>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    sqlx::query(
+        r#"
+        INSERT INTO users (address, username, display_name)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (address) DO UPDATE SET username = EXCLUDED.username
+        "#,
+    )
+    .bind(&event.address)
+    .bind(&event.username)
+    .bind(Some(&event.username))
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -535,6 +504,36 @@ mod tests {
         assert!(filters
             .iter()
             .any(|filter| filter["topics"][0][0]["value"] == "YieldAccrued"));
+    }
+
+    #[test]
+    fn payload_subscribes_to_user_registered_events() {
+        // #542: without this filter the indexer never receives registrations
+        // from the user_registry contract's `register_user`.
+        let payload = build_get_events_payload(1, None);
+        let filters = payload["params"][0]["filters"].as_array().unwrap();
+
+        assert!(filters
+            .iter()
+            .any(|filter| filter["topics"][0][0]["value"] == "UserRegistered"));
+    }
+
+    #[test]
+    fn parses_user_registered_event_payload() {
+        let payload = json!({
+            "address": "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567",
+            "username": "ebube",
+            "tx_hash": "deadbeef"
+        });
+
+        match parse_zaps_event("UserRegistered", &payload) {
+            ZapsEvent::UserRegistered(e) => {
+                assert_eq!(e.address, "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567");
+                assert_eq!(e.username, "ebube");
+                assert_eq!(e.tx_hash, "deadbeef");
+            }
+            _ => panic!("expected ZapsEvent::UserRegistered"),
+        }
     }
 
     #[test]

--- a/contracts/contracts/user_registry/src/lib.rs
+++ b/contracts/contracts/user_registry/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(unexpected_cfgs)]
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token, xdr::ToXdr, Address, Bytes,
-    BytesN, Env, String,
+    BytesN, Env, String, Symbol,
 };
 
 #[contract]
@@ -126,7 +126,13 @@ impl UserRegistryContract {
         env.storage().persistent().set(&username_key, &user);
         env.storage()
             .persistent()
-            .set(&DataKey::UserDeposit(user), &reservation_amount);
+            .set(&DataKey::UserDeposit(user.clone()), &reservation_amount);
+
+        // #542: publish so the off-chain indexer can sync this registration
+        // to the `users` table. Without this, on-chain registration and the
+        // off-chain database silently diverge.
+        env.events()
+            .publish((Symbol::new(&env, "UserRegistered"),), (user, username));
     }
 
     /// Retrieve the Address associated with a username


### PR DESCRIPTION
## Summary

Three compounding bugs made this feature impossible before this change:

1. **`contracts/user_registry`** — `register_user()` stored the address↔username mapping on-chain but never published an event (`update_profile` and `register_privy_did` both do; `register_user` silently didn't). There was nothing for an indexer to ever listen for.
2. **`indexer/parser.rs`** — `ZapsEvent` had no `UserRegistered` variant. It also had no `YieldAccrued` variant, despite `worker.rs`'s `process_event_batch_with_guard` already matching on `ZapsEvent::YieldAccrued` and a test already asserting a `"YieldAccrued"` filter existed — **the crate did not compile** on `master` before this PR.
3. **`indexer/worker.rs`** — `run()`, the actual indexer entry point spawned from `main.rs`, opened a Postgres transaction per poll, processed events through it, and never called `.commit()` or persisted the cursor. Every batch was silently rolled back the moment `tx` dropped at the end of the loop body. The already-tested, atomically-committing `process_event_batch_with_guard` existed in the same file but was never actually invoked from `run()`; `YieldCache` (needed for the `cache: Option<YieldCache>` parameter) wasn't even imported.

## Fixes, in order
- `register_user` now publishes `events().publish((Symbol::new(&env, "UserRegistered"),), (user, username))` after storing the mappings.
- `parser.rs`: added `YieldAccrued`/`UserRegistered` structs, enum variants, and `parse_zaps_event` match arms.
- `worker.rs`:
  - Added both topics to `build_get_events_payload`'s filters.
  - Added `process_user_registered_event` — upserts the real on-chain username into `users`, **unconditionally** overwriting any placeholder slug from `get_or_create_user_id_tx` (a `UserRegistered` event is authoritative, unlike the `COALESCE`-guarded placeholder path used for yield/payment events where the address is the only known fact).
  - Rewrote `run()` to delegate to `process_event_batch_with_guard` instead of duplicating the same event-matching logic inline with a fragile topic-guessing heuristic — this fixes the missing commit / cursor-persist / cache-invalidation bugs as one change, and removes the now-dead pool-based `get_or_create_user_id`.

## Acceptance criteria
- [x] Parse registration events — `UserRegistered` variant + parser
- [x] Insert or update the user records in off-chain database — `process_user_registered_event`, and now actually reachable since `run()` commits

## Test plan
No automated tests run (out of scope for this change per task instructions — this includes not running `cargo build`/`cargo test`, so please verify in CI). Added unit tests for the new filter and parse path (`payload_subscribes_to_user_registered_events`, `parses_user_registered_event_payload`), matching the existing style for `YieldAccrued`.

Closes #542