### PR TITLE
feat(api): payout route resolves username to Stellar address, builds XDR

### DIFF
--- a/backend/src/api/feed.rs
+++ b/backend/src/api/feed.rs
@@ -401,3 +401,88 @@ pub async fn get_private_feed(
         }
     }
 }
+
+// ── #543: payout by username ───────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct PayoutByUsernameRequest {
+    pub username: String,
+    /// Payout amount in stroops (1 XLM = 10_000_000 stroops).
+    pub amount: i64,
+}
+
+#[derive(Serialize)]
+pub struct PayoutByUsernameResponse {
+    pub envelope_xdr: String,
+    pub recipient_address: String,
+}
+
+/// POST /api/payout/username — resolve `username` to its registered Stellar
+/// address and return an unsigned payment transaction envelope from the
+/// authenticated caller to that address. The client wallet is responsible
+/// for setting the real sequence number, signing, and submitting.
+pub async fn payout_by_username(
+    State(pool): State<PgPool>,
+    auth: AuthUser,
+    Json(payload): Json<PayoutByUsernameRequest>,
+) -> impl IntoResponse {
+    if payload.amount <= 0 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "amount must be positive" })),
+        )
+            .into_response();
+    }
+
+    let row = sqlx::query("SELECT address FROM users WHERE username = $1")
+        .bind(&payload.username)
+        .fetch_optional(&pool)
+        .await;
+
+    let recipient_address: String = match row {
+        Ok(Some(row)) => row.get("address"),
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "username not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to resolve username for payout: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Internal database error" })),
+            )
+                .into_response();
+        }
+    };
+
+    if recipient_address == auth.address {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "cannot pay yourself" })),
+        )
+            .into_response();
+    }
+
+    match crate::services::stellar::build_payout_envelope_xdr(
+        &auth.address,
+        &recipient_address,
+        payload.amount,
+    ) {
+        Ok(envelope_xdr) => Json(PayoutByUsernameResponse {
+            envelope_xdr,
+            recipient_address,
+        })
+        .into_response(),
+        Err(e) => {
+            tracing::error!("Failed to build payout envelope: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to build transaction" })),
+            )
+                .into_response()
+        }
+    }
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -39,6 +39,13 @@ pub fn feed_routes(pool: sqlx::PgPool) -> Router {
         .with_state(pool)
 }
 
+/// #543
+pub fn payout_routes(pool: sqlx::PgPool) -> Router {
+    Router::new()
+        .route("/username", post(feed::payout_by_username))
+        .with_state(pool)
+}
+
 pub fn social_routes(pool: sqlx::PgPool) -> Router {
     Router::new()
         .route("/like", post(social::like_payment))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -213,7 +213,11 @@ async fn main() {
 
     let sensitive_routes = Router::new()
         .nest("/api/auth", api::auth_routes(pool.clone()))
-        .nest("/api/users", api::user_routes(pool.clone()));
+        .nest("/api/users", api::user_routes(pool.clone()))
+        // #543: payout constructs a real payment transaction envelope, so it
+        // gets the same rate-limiting as auth/users rather than sitting in
+        // other_routes.
+        .nest("/api/payout", api::payout_routes(pool.clone()));
 
     let other_routes = Router::new()
         .nest("/api/feed", api::feed_routes(pool.clone()))

--- a/backend/src/services/stellar.rs
+++ b/backend/src/services/stellar.rs
@@ -1,6 +1,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::time::Duration;
+use stellar_base::{
+    amount::Stroops,
+    network::Network,
+    operations::Operation,
+    transaction::{Transaction, MIN_BASE_FEE},
+    xdr::XDRSerialize,
+    Asset, PublicKey,
+};
 
 // Stellar/Soroban Horizon & RPC operations client stub
 // This client interacts with Stellar RPC nodes and Horizon endpoints.
@@ -113,6 +121,61 @@ impl StellarClient {
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         Ok("tx_hash_placeholder".to_string())
     }
+}
+
+/// #543: build a base64-encoded, unsigned Stellar XDR `TransactionEnvelope`
+/// (v1) paying `amount_stroops` of native XLM from `source_account` to
+/// `destination_account`, for the payout-by-username route.
+///
+/// Sequence is a `0` sentinel — same convention as
+/// `api::yield::build_stellar_envelope_xdr` — the signing wallet (or a
+/// pre-submission `getAccount` call) must substitute the real sequence + 1
+/// before signing. Network is selected from `STELLAR_NETWORK` the same way.
+pub fn build_payout_envelope_xdr(
+    source_account: &str,
+    destination_account: &str,
+    amount_stroops: i64,
+) -> Result<String, String> {
+    if amount_stroops <= 0 {
+        return Err("amount must be positive".to_string());
+    }
+
+    let source_pk = PublicKey::from_account_id(source_account)
+        .map_err(|e| format!("invalid source account: {e}"))?;
+    let destination_pk = PublicKey::from_account_id(destination_account)
+        .map_err(|e| format!("invalid destination account: {e}"))?;
+
+    let payment_op = Operation::new_payment()
+        .with_destination(destination_pk)
+        .with_asset(Asset::new_native())
+        .with_amount(Stroops::new(amount_stroops))
+        .map_err(|e| format!("payment op amount error: {e}"))?
+        .build()
+        .map_err(|e| format!("payment op error: {e}"))?;
+
+    // Sequence 0 is a sentinel; wallets must substitute the real value.
+    let sequence: i64 = 0;
+    let tx = Transaction::builder(source_pk, sequence, MIN_BASE_FEE)
+        .add_operation(payment_op)
+        .into_transaction()
+        .map_err(|e| format!("transaction build error: {e}"))?;
+
+    // Select network from environment (default: testnet) — kept for parity
+    // with build_stellar_envelope_xdr even though it isn't consumed further
+    // here; XDR serialization itself isn't network-dependent.
+    let _network = match std::env::var("STELLAR_NETWORK")
+        .unwrap_or_default()
+        .to_lowercase()
+        .as_str()
+    {
+        "mainnet" | "public" => Network::new_public(),
+        _ => Network::new_test(),
+    };
+
+    let envelope = tx.into_envelope();
+    envelope
+        .xdr_base64()
+        .map_err(|e| format!("XDR serialization error: {e}"))
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Adds `POST /api/payout/username`: given an authenticated caller and a target `username`, resolve the recipient's registered Stellar address from `users` (reliably populated now that #542 wires up `UserRegistered` indexing) and return an unsigned native-XLM payment transaction envelope from the caller to that address.

- **`services/stellar.rs`** — `build_payout_envelope_xdr()`: a real `Payment` operation via `stellar-base` (`Operation::new_payment` + `Asset::new_native`), as opposed to `api::yield::build_stellar_envelope_xdr`'s `ManageData`-only envelope (that one tags metadata; this one actually moves value). Same `sequence = 0` sentinel and `STELLAR_NETWORK` selection convention as the existing builder, so wallets integrate with it identically.
- **`api/feed.rs`** — `payout_by_username` handler: validates a positive amount, resolves the username, rejects self-payment, and returns `{ envelope_xdr, recipient_address }` or the appropriate 400/404/500.
- **`api/mod.rs` + `main.rs`** — new `payout_routes()`, nested at `/api/payout` (matching the issue's literal endpoint path), placed in the **rate-limited** `sensitive_routes` group alongside auth/users rather than the unrated `other_routes` group, since this endpoint constructs real payment transactions.

## Acceptance criteria
- [x] Resolve target user address — DB lookup by username in `users`
- [x] Build and return base64 transaction XDR payload — `envelope_xdr` in the response

## Test plan
No automated tests run (out of scope per task instructions — this includes not running `cargo build`/`cargo test`, so please verify in CI). I did verify the `stellar-base` 0.7.0 API surface used here (`PaymentOperationBuilder`, `Asset::new_native`, `Stroops::new`, `From<PublicKey> for MuxedAccount`) against docs.rs before writing it, since I couldn't compile locally.

Closes #543