### PR TITLE
feat(cache): integrate Redis cache for username-to-address mappings

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -17,7 +17,13 @@ pub fn auth_routes(pool: sqlx::PgPool) -> Router {
         .with_state(pool)
 }
 
+/// User routes without a Redis cache; username resolution falls through to Postgres.
 pub fn user_routes(pool: sqlx::PgPool) -> Router {
+    user_routes_with_state(user::UserState::new(pool, None))
+}
+
+/// #544: User routes wired to the Redis username->address cache.
+pub fn user_routes_with_state(state: user::UserState) -> Router {
     Router::new()
         .route(
             "/profile",
@@ -28,7 +34,8 @@ pub fn user_routes(pool: sqlx::PgPool) -> Router {
         .route("/friends/request", post(user::send_friend_request))
         .route("/friends/:id/accept", post(user::accept_friend_request))
         .route("/friends/:id/reject", post(user::reject_friend_request))
-        .with_state(pool)
+        .route("/resolve/:username", get(user::resolve_address))
+        .with_state(state)
 }
 
 pub fn feed_routes(pool: sqlx::PgPool) -> Router {

--- a/backend/src/api/user.rs
+++ b/backend/src/api/user.rs
@@ -1,6 +1,7 @@
 use crate::api::feed::AuthUser;
+use crate::services::redis_cache::UsernameAddressCache;
 use axum::{
-    extract::{Path, State},
+    extract::{FromRef, Path, State},
     http::StatusCode,
     response::IntoResponse,
     Json,
@@ -8,6 +9,28 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 use uuid::Uuid;
+
+/// #544: state for routes that need the username->address Redis cache
+/// alongside the DB pool. Existing handlers keep extracting `State<PgPool>`
+/// directly (via the `FromRef` impl below) — only `resolve_address` needs
+/// the full state.
+#[derive(Clone)]
+pub struct UserState {
+    pub pool: sqlx::PgPool,
+    pub cache: Option<UsernameAddressCache>,
+}
+
+impl UserState {
+    pub fn new(pool: sqlx::PgPool, cache: Option<UsernameAddressCache>) -> Self {
+        Self { pool, cache }
+    }
+}
+
+impl FromRef<UserState> for sqlx::PgPool {
+    fn from_ref(state: &UserState) -> Self {
+        state.pool.clone()
+    }
+}
 
 #[derive(Deserialize)]
 pub struct UpdateProfileRequest {
@@ -368,6 +391,56 @@ pub async fn reject_friend_request(
         Ok(_) => Json(serde_json::json!({ "status": "REJECTED" })).into_response(),
         Err(e) => {
             tracing::error!("reject_friend_request failed: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Internal database error" })),
+            )
+                .into_response()
+        }
+    }
+}
+
+// ── #544: cached username -> address resolution ────────────────────────────
+
+#[derive(Serialize)]
+pub struct ResolveAddressResponse {
+    pub username: String,
+    pub address: String,
+}
+
+/// GET /api/users/resolve/:username — resolve a username to its registered
+/// Stellar address for transfer/payout flows, checking the Redis cache
+/// before Postgres and populating it (30-minute TTL) on a DB hit.
+pub async fn resolve_address(
+    State(state): State<UserState>,
+    Path(username): Path<String>,
+) -> impl IntoResponse {
+    if let Some(cache) = &state.cache {
+        if let Some(address) = cache.get_address(&username).await {
+            return Json(ResolveAddressResponse { username, address }).into_response();
+        }
+    }
+
+    let row = sqlx::query("SELECT address FROM users WHERE username = $1")
+        .bind(&username)
+        .fetch_optional(&state.pool)
+        .await;
+
+    match row {
+        Ok(Some(row)) => {
+            let address: String = row.get("address");
+            if let Some(cache) = &state.cache {
+                cache.set_address(&username, &address).await;
+            }
+            Json(ResolveAddressResponse { username, address }).into_response()
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "username not found" })),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("Failed to resolve username: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({ "error": "Internal database error" })),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -196,6 +196,25 @@ async fn main() {
         }
     };
 
+    // #544: Redis-backed username->address cache, shared REDIS_URL with the
+    // yield cache above. Absent/unusable REDIS_URL simply falls through to
+    // Postgres on every username resolution.
+    let username_address_cache = match config.redis_url.as_deref() {
+        Some(url) => match services::redis_cache::UsernameAddressCache::connect(url) {
+            Ok(cache) => {
+                tracing::info!("Username->address cache enabled against Redis");
+                Some(cache)
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to initialize username->address cache, continuing without it: {e}"
+                );
+                None
+            }
+        },
+        None => None,
+    };
+
     // Bridge state: shares the DB pool and the Allbridge API client.
     let bridge_state =
         api::bridge::BridgeState::new(pool.clone(), config.allbridge_api_url.clone());
@@ -213,7 +232,13 @@ async fn main() {
 
     let sensitive_routes = Router::new()
         .nest("/api/auth", api::auth_routes(pool.clone()))
-        .nest("/api/users", api::user_routes(pool.clone()));
+        .nest(
+            "/api/users",
+            api::user_routes_with_state(api::user::UserState::new(
+                pool.clone(),
+                username_address_cache.clone(),
+            )),
+        );
 
     let other_routes = Router::new()
         .nest("/api/feed", api::feed_routes(pool.clone()))

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod allbridge;
 pub mod notifications;
+pub mod redis_cache;
 pub mod stellar;
 pub mod sweep_worker;
 pub mod yield_calc;

--- a/backend/src/services/redis_cache.rs
+++ b/backend/src/services/redis_cache.rs
@@ -1,0 +1,106 @@
+use redis::{
+    aio::{ConnectionManager, ConnectionManagerConfig},
+    RedisError,
+};
+use std::time::Duration;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// #544: 30-minute TTL for cached username -> address mappings, per the
+/// issue's acceptance criteria.
+const USERNAME_ADDRESS_TTL_SECS: u64 = 30 * 60;
+
+fn cache_key(username: &str) -> String {
+    format!("zaps:user:address:{username}")
+}
+
+/// Redis-backed cache for username -> Stellar address resolution, so
+/// transfer/payout flows don't hit Postgres on every lookup.
+///
+/// Mirrors `api::yield::YieldCache`'s shape and failure handling: connects
+/// lazily so a Redis outage at boot doesn't prevent the API from starting,
+/// and every operation degrades to "treat as a cache miss" on error rather
+/// than surfacing a Redis failure to the caller — Postgres is always the
+/// source of truth.
+#[derive(Clone)]
+pub struct UsernameAddressCache {
+    pool: ConnectionManager,
+}
+
+impl UsernameAddressCache {
+    pub fn connect(redis_url: &str) -> Result<Self, RedisError> {
+        let client = redis::Client::open(redis_url)?;
+        let config = ConnectionManagerConfig::new()
+            .set_connection_timeout(Some(CONNECT_TIMEOUT))
+            .set_response_timeout(Some(RESPONSE_TIMEOUT));
+
+        Ok(Self {
+            pool: ConnectionManager::new_lazy_with_config(client, config)?,
+        })
+    }
+
+    /// Retrieve a cached address for `username`. A miss — or any Redis
+    /// error — is reported as `None` so the caller falls back to Postgres.
+    pub async fn get_address(&self, username: &str) -> Option<String> {
+        match redis::cmd("GET")
+            .arg(cache_key(username))
+            .query_async::<Option<String>>(&mut self.pool.clone())
+            .await
+        {
+            Ok(cached) => cached,
+            Err(e) => {
+                tracing::warn!("username->address cache read failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// Cache `address` for `username` with a 30-minute expiration.
+    pub async fn set_address(&self, username: &str, address: &str) {
+        if let Err(e) = redis::cmd("SET")
+            .arg(cache_key(username))
+            .arg(address)
+            .arg("EX")
+            .arg(USERNAME_ADDRESS_TTL_SECS)
+            .query_async::<()>(&mut self.pool.clone())
+            .await
+        {
+            tracing::warn!("username->address cache write failed: {e}");
+        }
+    }
+
+    /// Evict a cached mapping.
+    ///
+    /// Intended to be called by the indexer when a `UserRegistered` event is
+    /// indexed for this username, per this issue's guidance ("Invalidate
+    /// cache entries if user registry changes are index-logged"). Wire this
+    /// into `indexer::worker::process_user_registered_event` once that
+    /// lands, so a fresh registration is never masked by a stale cache
+    /// entry for the remainder of its 30-minute TTL.
+    pub async fn invalidate(&self, username: &str) {
+        if let Err(e) = redis::cmd("DEL")
+            .arg(cache_key(username))
+            .query_async::<()>(&mut self.pool.clone())
+            .await
+        {
+            tracing::warn!("username->address cache invalidation failed: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_is_namespaced_per_username() {
+        assert_eq!(cache_key("ebube"), "zaps:user:address:ebube");
+        assert_ne!(cache_key("ebube"), cache_key("chidi"));
+    }
+
+    #[test]
+    fn connect_rejects_a_non_redis_url() {
+        assert!(UsernameAddressCache::connect("postgres://localhost/zaps").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Redis-backed cache for username -> Stellar address resolution, so transfer/payout flows don't hit Postgres on every lookup.

- **`services/redis_cache.rs`** — `UsernameAddressCache`, mirroring `api::yield::YieldCache`'s shape and failure handling: connects lazily so a Redis outage at boot doesn't block startup, and every operation degrades to "treat as a cache miss" on error rather than propagating a Redis failure — Postgres remains the source of truth. `get_address` / `set_address` (30-minute TTL, per acceptance criteria) / `invalidate`.
- **`api/user.rs`** — `UserState` (pool + `Option<UsernameAddressCache>`), mirroring the existing `YieldState`/`FromRef<PgPool>` pattern so all existing handlers keep extracting `State<PgPool>` unchanged. New `resolve_address` handler: checks the cache first, falls back to Postgres on a miss, and populates the cache on a DB hit.
- **`api/mod.rs`** — `user_routes_with_state` (mirrors `yield_routes_with_state`) plus a new `GET /api/users/resolve/:username` route; `user_routes(pool)` still works unchanged as a no-cache wrapper.
- **`main.rs`** — constructs the cache from the same `REDIS_URL` as the yield cache, wires `user_routes_with_state` into `sensitive_routes`.

## A note on the invalidation guidance
This issue's guidance says to "invalidate cache entries if user registry changes are index-logged" — i.e. wire eviction into the indexer's handling of `UserRegistered` events. That handling (`process_user_registered_event`) doesn't exist on `master` yet — it's part of my separate PR for #542, still open. Wiring `UsernameAddressCache::invalidate(&event.username)` into it now would mean editing code that doesn't exist here, so I've left `invalidate()` implemented and documented as the integration point, with a note for whoever merges #542 to call it from `process_user_registered_event`. Happy to open that follow-up PR myself once #542 lands if that's easier.

## Acceptance criteria
- [x] Retrieve username mappings from Redis first — `resolve_address` checks `cache.get_address` before querying Postgres
- [x] Cache query results with expiration time of 30 minutes — `USERNAME_ADDRESS_TTL_SECS`

## Test plan
No automated tests run (out of scope per task instructions — this includes not running `cargo build`/`cargo test`, so please verify in CI). Added unit tests for the cache-key namespacing and the connect-rejects-bad-url case, matching the existing `YieldCache` test style.

Closes #544