### PR TITLE
feat(db): add migration for historical yield accrual logging

### DIFF
--- a/backend/migrations/20260724000000_yield_tables.sql
+++ b/backend/migrations/20260724000000_yield_tables.sql
@@ -1,0 +1,24 @@
+-- #546: historical log of on-chain yield-vault accrual events.
+--
+-- Deposits are already tracked in yield_transactions, and administrator/
+-- rate-setter APY changes are already tracked in yield_rates_history (both
+-- from 20260625000000_create_yield_tables.sql). Neither captures the vault's
+-- own periodic compounding: the indexer's YieldAccrued handling
+-- (indexer::worker::process_event_batch_with_guard) currently only logs
+-- these via tracing and marks the platform yield cache dirty — the event
+-- data itself is never persisted, so there is no historical record of how
+-- much yield accrued, over how many ledgers, or what the new index was.
+--
+-- This table is platform-wide (not per-user), matching the vault-level
+-- nature of the on-chain event; individual user balances continue to be
+-- read from user_yield_balances / yield_transactions as before.
+CREATE TABLE IF NOT EXISTS yield_accrual_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tx_hash VARCHAR(64) UNIQUE NOT NULL,
+    added_yield BIGINT NOT NULL,
+    elapsed_ledgers BIGINT NOT NULL,
+    new_index BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_yield_accrual_log_created_at ON yield_accrual_log(created_at DESC);


### PR DESCRIPTION
## Summary

Checked the existing migrations first: `deposits` (`yield_transactions`) and `yield rate changes` (`yield_rates_history`) are already fully covered by `20260625000000_create_yield_tables.sql` (+ `last_yield_sync_at` added in `20260627000000_yield_auto_earn_and_notifications.sql`). Both already correctly relate `user_id UUID REFERENCES users(id)`, with the Stellar address living on `users.address` — matching this issue's guidance.

What's missing is the third acceptance-criteria item, **interest/APY accrual logs**: the indexer's `YieldAccrued` event handling in `indexer::worker::process_event_batch_with_guard` only logs the event via `tracing::info!` and marks the platform yield cache dirty — the event data itself (`added_yield`, `elapsed_ledgers`, `new_index`) is never persisted anywhere, so there's no historical record of the vault's own periodic compounding (distinct from `yield_rates_history`, which tracks administrator/rate-setter APY changes, not vault accrual).

This adds `yield_accrual_log`:
- Platform-wide (not per-user), matching the vault-level nature of the on-chain event.
- One row per `YieldAccrued` event: `added_yield`, `elapsed_ledgers`, `new_index`, `tx_hash` (unique, so a re-indexed event can't double-log), `created_at`.
- Indexed on `created_at DESC` for the obvious "recent accrual history" query, matching the existing convention on `yield_rates_history`/`yield_transactions`.

## Follow-up (out of scope here)
This issue's file list is just the migration. Once this lands, the natural next step is wiring an `INSERT INTO yield_accrual_log` into `process_event_batch_with_guard`'s `ZapsEvent::YieldAccrued` arm — mirroring how `log_yield_rate_update_tx` already persists `YieldRateUpdated` — so the table actually gets populated. Happy to open that as a follow-up PR.

## Acceptance criteria
- [x] Setup schema for deposits — already existed (`yield_transactions`)
- [x] interest logs — new `yield_accrual_log` table (this PR)
- [x] yield rate changes — already existed (`yield_rates_history`)

## Test plan
No automated tests run (out of scope per task instructions, so please verify in CI / a local `sqlx migrate run`). `sqlx::migrate!()` auto-discovers files in `backend/migrations` by filename, so no registration step beyond adding the file.

Closes #546