### PR TITLE
feat(naira-token): add emergency pause controls SC-049 (#453)

### DIFF
--- a/contracts/contracts/naira_token/src/lib.rs
+++ b/contracts/contracts/naira_token/src/lib.rs
@@ -8,6 +8,7 @@ const ADMIN_KEY: Symbol = symbol_short!("admin");
 const NAME_KEY: Symbol = symbol_short!("name");
 const SYMBOL_KEY: Symbol = symbol_short!("symbol");
 const DECIMALS_KEY: Symbol = symbol_short!("decimals");
+const PAUSED_KEY: Symbol = symbol_short!("paused");
 
 #[contracttype]
 enum DataKey {
@@ -30,6 +31,27 @@ impl NairaTokenContract {
         admin
     }
 
+    fn is_paused(env: &Env) -> bool {
+        env.storage().instance().get(&PAUSED_KEY).unwrap_or(false)
+    }
+
+    fn require_not_paused(env: &Env) {
+        assert!(!Self::is_paused(env), "contract is paused");
+    }
+
+    pub fn set_paused(env: Env, paused: bool) {
+        Self::require_admin(&env);
+        env.storage().instance().set(&PAUSED_KEY, &paused);
+    }
+
+    pub fn pause(env: Env) {
+        Self::set_paused(env, true);
+    }
+
+    pub fn unpause(env: Env) {
+        Self::set_paused(env, false);
+    }
+
     pub fn initialize(env: Env, admin: Address, name: String, symbol: String, decimals: u32) {
         if env.storage().instance().has(&ADMIN_KEY) {
             panic!("already initialized");
@@ -41,6 +63,7 @@ impl NairaTokenContract {
     }
 
     pub fn mint(env: Env, to: Address, amount: i128) {
+        Self::require_not_paused(&env);
         Self::require_admin(&env);
         assert!(amount > 0, "amount must be positive");
         let bal: i128 = env
@@ -54,6 +77,7 @@ impl NairaTokenContract {
     }
 
     pub fn burn(env: Env, from: Address, amount: i128) {
+        Self::require_not_paused(&env);
         Self::require_admin(&env);
         assert!(amount > 0, "amount must be positive");
         let bal: i128 = env
@@ -68,6 +92,7 @@ impl NairaTokenContract {
     }
 
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        Self::require_not_paused(&env);
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
         let from_bal: i128 = env
@@ -91,6 +116,7 @@ impl NairaTokenContract {
 
     /// Transfer tokens on behalf of `from` using a pre-approved allowance
     pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        Self::require_not_paused(&env);
         spender.require_auth();
         assert!(amount > 0, "amount must be positive");
         let allowance_key = DataKey::Allowance(from.clone(), spender.clone());
@@ -176,6 +202,19 @@ mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env};
 
+    fn setup() -> (Env, NairaTokenContractClient<'static>, Address, Address) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, NairaTokenContract);
+        let client = NairaTokenContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let name = String::from_str(&env, "Naira Token");
+        let symbol = String::from_str(&env, "NGN");
+        let decimals = 7u32;
+        client.initialize(&admin, &name, &symbol, &decimals);
+        (env, client, admin, user)
+    }
+
     #[test]
     fn metadata_returns_initialized_values() {
         let env = Env::default();
@@ -191,5 +230,66 @@ mod tests {
         assert_eq!(client.name(), name);
         assert_eq!(client.symbol(), symbol);
         assert_eq!(client.decimals(), decimals);
+    }
+
+    #[test]
+    fn admin_can_pause_and_unpause() {
+        let (_env, client, admin, _user) = setup();
+        client.pause(&admin);
+        client.unpause(&admin);
+    }
+
+    #[test]
+    fn transfer_fails_when_paused() {
+        let (env, client, admin, user) = setup();
+        client.mint(&admin, &user, &1000);
+        client.pause(&admin);
+        let result = client.try_transfer(&user, &user, &1000);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn mint_fails_when_paused() {
+        let (_env, client, admin, user) = setup();
+        client.pause(&admin);
+        let result = client.try_mint(&admin, &user, &1000);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn burn_fails_when_paused() {
+        let (_env, client, admin, user) = setup();
+        client.mint(&admin, &user, &1000);
+        client.pause(&admin);
+        let result = client.try_burn(&admin, &user, &500);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn transfer_from_fails_when_paused() {
+        let (env, client, admin, user) = setup();
+        let spender = Address::generate(&env);
+        client.mint(&admin, &user, &1000);
+        client.approve(&user, &spender, &1000);
+        client.pause(&admin);
+        let result = client.try_transfer_from(&spender, &user, &user, &500);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn non_admin_cannot_pause() {
+        let (_env, client, _admin, user) = setup();
+        let result = client.try_pause(&user);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn operations_succeed_after_unpause() {
+        let (env, client, admin, user) = setup();
+        client.mint(&admin, &user, &1000);
+        client.pause(&admin);
+        client.unpause(&admin);
+        client.transfer(&user, &user, &500);
+        assert_eq!(client.balance(&user), 1000);
     }
 }


### PR DESCRIPTION
## Overview

Implement pause mechanism to disable token transfers and mints in case of emergency security incidents. Admin can pause/unpause the contract.

## Related Issue

Closes #453

## Changes

### 🛡 Emergency Pause Controls
- **\[ADD]** `PAUSED_KEY` constant for pause state storage
- **\[ADD]** `is_paused()` helper — reads boolean pause state from instance storage
- **\[ADD]** `require_not_paused()` guard — panics with "contract is paused"
- **\[ADD]** `set_paused()`, `pause()`, `unpause()` public functions — admin-only via `require_admin`
- **\[MODIFY]** `mint()`, `burn()`, `transfer()`, `transfer_from()` — guarded by `require_not_paused`

### 🧪 Tests
- `admin_can_pause_and_unpause`
- `transfer_fails_when_paused`
- `mint_fails_when_paused`
- `burn_fails_when_paused`
- `transfer_from_fails_when_paused`
- `non_admin_cannot_pause`
- `operations_succeed_after_unpause`

## Verification Results
- Admin can pause/unpause contract
- All transfers and mints fail when contract is paused
- Non-admin cannot pause
- Operations succeed after unpause