### PR TITLE
feat(mobileapp): update home dashboard balance card split into available and earning sections

### DIFF
--- a/mobileapp/app/(personal)/home.tsx
+++ b/mobileapp/app/(personal)/home.tsx
@@ -634,13 +634,19 @@ export default function HomeScreen() {
       >
         {/* Balance Card */}
         <View style={styles.balanceCard}>
-          <Text style={styles.balanceLabel}>Available Balance</Text>
-          <Text style={styles.balanceAmount}>{availableBalance}</Text>
+          {/* Available Balance Section */}
+          <View style={styles.balanceSection}>
+            <Text style={styles.balanceLabel}>Available Balance</Text>
+            <Text style={styles.balanceAmount}>{availableBalance}</Text>
+          </View>
 
-          <View style={styles.earningRow}>
-            <View style={styles.earningDot} />
-            <Text style={styles.earningRowLabel}>Earning Balance</Text>
-            <Text style={styles.earningRowValue}>{totalYieldEarned}</Text>
+          {/* Earning Balance Section */}
+          <View style={styles.earningBalanceSection}>
+            <View style={styles.earningBalanceHeader}>
+              <View style={styles.earningDot} />
+              <Text style={styles.earningRowLabel}>Earning Balance</Text>
+            </View>
+            <Text style={styles.earningBalanceAmount}>{totalYieldEarned}</Text>
           </View>
 
           <TouchableOpacity
@@ -1258,6 +1264,9 @@ const styles = StyleSheet.create({
     shadowRadius: 10,
     elevation: 2,
   },
+  balanceSection: {
+    marginBottom: 16,
+  },
   balanceLabel: {
     fontSize: 13,
     fontFamily: "Outfit_400Regular",
@@ -1268,17 +1277,19 @@ const styles = StyleSheet.create({
     fontSize: 34,
     fontFamily: "Outfit_700Bold",
     color: COLORS.primary,
-    marginBottom: 14,
   },
-  earningRow: {
+  earningBalanceSection: {
+    backgroundColor: "#F2F9F0",
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 20,
+    borderWidth: 1,
+    borderColor: "#E8F5E9",
+  },
+  earningBalanceHeader: {
     flexDirection: "row",
     alignItems: "center",
-    alignSelf: "flex-start",
-    backgroundColor: "#F2F9F0",
-    borderRadius: 999,
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    marginBottom: 20,
+    marginBottom: 8,
   },
   earningDot: {
     width: 8,
@@ -1291,10 +1302,9 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontFamily: "Outfit_500Medium",
     color: "#456047",
-    marginRight: 8,
   },
-  earningRowValue: {
-    fontSize: 13,
+  earningBalanceAmount: {
+    fontSize: 28,
     fontFamily: "Outfit_700Bold",
     color: "#2E7D32",
   },


### PR DESCRIPTION
Closes #570

## Summary
Modifies the home dashboard balance card to show available and earning balances separately with contrasting color accents. The earning balance is now displayed in a distinct section with green-tinted styling to improve visual hierarchy and make it easier for users to distinguish between their available funds and funds currently earning yield.

## Changes
- Split balance card into two distinct sections: available balance and earning balance
- Added `balanceSection` style to containerize available balance display
- Added `earningBalanceSection` style with green background (#F2F9F0) and border (#E8F5E9) for the earning balance
- Added `earningBalanceHeader` style to organize the earning label with indicator dot
- Added `earningBalanceAmount` style with larger font (28px) and green color (#2E7D32) for the earning balance value
- Removed previous inline `earningRow` layout in favor of dedicated card section
- Maintained existing quick actions (Pay/Request, Receive, Fund) below the balance sections

## Acceptance Criteria
- Available balance displayed with primary color accent
- Earning balance displayed in separate section with green accent colors
- Numeric balances shown clearly with appropriate font sizes
- Design follows core styles without heavy borders or generic layouts
- Visual hierarchy improved through contrasting color accents

## Technical Details
- Uses existing state variables: `availableBalance` and `totalYieldEarned`
- Earning section uses light green background (#F2F9F0) with darker green border (#E8F5E9)
- Earning amount uses bold green color (#2E7D32) at 28px font size
- Available balance maintains original primary color styling at 34px font size
- Maintains existing card shadow and border styling for consistency

## Testing
Test the mobile app home screen to verify:
- Balance card displays both available and earning sections
- Earning balance section has green accent colors
- Numeric balances render correctly
- Quick action buttons remain functional below balance sections