### PR TITLE
feat: connect yield screens to live backend endpoints (#575)

### DIFF
--- a/mobileapp/app/(personal)/home.tsx
+++ b/mobileapp/app/(personal)/home.tsx
@@ -130,8 +130,8 @@ export default function HomeScreen() {
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<"public" | "friends">("public");
   const [feed, setFeed] = useState<FeedItem[]>(INITIAL_FEED);
-  const [availableBalance] = useState("₦32,450.00");
-  const [totalYieldEarned] = useState("₦3,280.45");
+  const [availableBalance, setAvailableBalance] = useState("₦0.00");
+  const [totalYieldEarned, setTotalYieldEarned] = useState("₦0.00");
   const [yieldData, setYieldData] = useState<YieldSnapshot | null>(null);
   const [yieldStatus, setYieldStatus] = useState<
     "loading" | "success" | "error"
@@ -176,9 +176,31 @@ export default function HomeScreen() {
   const fetchYieldSnapshot = async (): Promise<YieldSnapshot> => {
     const data = await fetchYieldBalance();
     setAutoYieldEnabled(data.autoEarnEnabled);
+    
+    const formatCurr = (val: number) =>
+      `₦${val.toLocaleString("en-NG", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`;
+
+    // Parse numbers formatting correctly
+    const parseAPIValue = (val: string | number) => {
+      if (typeof val === "number") return formatCurr(val);
+      const strVal = String(val);
+      if (strVal.includes("₦")) return strVal;
+      const parsed = Number(strVal);
+      return isNaN(parsed) ? strVal : formatCurr(parsed);
+    };
+
+    const formattedYield = parseAPIValue(data.totalYieldEarned);
+    const formattedAvailable = parseAPIValue(data.availableBalance);
+    
+    setAvailableBalance(formattedAvailable);
+    setTotalYieldEarned(formattedYield);
+    
     return {
-      apy: data.apy,
-      totalYieldEarned: data.totalYieldEarned,
+      apy: typeof data.apy === "number" ? `${data.apy}%` : String(data.apy).includes("%") ? String(data.apy) : `${data.apy}%`,
+      totalYieldEarned: formattedYield,
       explanation: data.explanation,
     };
   };

--- a/mobileapp/src/services/api.ts
+++ b/mobileapp/src/services/api.ts
@@ -12,32 +12,19 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
 }
 
 export interface YieldBalance {
-  apy: string;
-  totalYieldEarned: string;
-  availableBalance: string;
-  earningBalance: string;
+  apy: string | number;
+  totalYieldEarned: string | number;
+  availableBalance: string | number;
+  earningBalance: string | number;
   explanation: string;
   autoEarnEnabled: boolean;
 }
 
 export async function fetchYieldBalance(): Promise<YieldBalance> {
   const headers = await getAuthHeaders();
-  try {
-    const res = await fetch(`${API_BASE}/api/yield/balance`, { headers });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return res.json() as Promise<YieldBalance>;
-  } catch {
-    // Fallback to mock while backend is not yet live
-    return {
-      apy: "8.75%",
-      totalYieldEarned: "₦3,280.45",
-      availableBalance: "₦32,450.00",
-      earningBalance: "₦3,280.45",
-      explanation:
-        "Your earnings are generated from your wallet balance and may vary as rates change. APY is an annualized estimate and total yield is updated automatically over time.",
-      autoEarnEnabled: true,
-    };
-  }
+  const res = await fetch(`${API_BASE}/api/yield/balance`, { headers });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<YieldBalance>;
 }
 
 export async function updateAutoEarn(enabled: boolean): Promise<void> {


### PR DESCRIPTION
## What
This PR connects the Home screen yield interface directly to the `/api/yield/balance` backend endpoint and handles real data formatting, addressing issue #575.

## Why
Previously, `home.tsx` relied on hardcoded `useState` strings for `availableBalance` and `totalYieldEarned`, and `api.ts` returned a mocked payload if the backend fetch failed. Now that the backend is live, we need to strip out these mocks, properly parse incoming numeric values, and update the UI states dynamically when users refresh. 

## Implementation Details
- **API Updates**: Removed the mock catch-block in `fetchYieldBalance()` and updated the `YieldBalance` interface so it gracefully accepts either `string` or `number` values from the backend. Authorization header injection (Bearer token) was reviewed and remains functionally intact.
- **State Binding**: Upgraded the `availableBalance` and `totalYieldEarned` hooks in `home.tsx` to include setters.
- **Data Formatting**: Added a `parseAPIValue` helper inside `fetchYieldSnapshot` to sanitize and correctly format raw numeric responses (or unformatted string responses) into properly localized `₦` strings with 2 decimal places. 

Closes #575
