### PR TITLE
feat(recent-recipients): implement caching for recent recipient usern…

### DIFF
--- a/mobileapp/app/transfer.tsx
+++ b/mobileapp/app/transfer.tsx
@@ -31,6 +31,7 @@ import {
   getLocalKeypair,
   StellarWalletState,
 } from "../src/services/stellarWallet";
+import { getRecentRecipients, saveRecentRecipient } from "../src/services/api";
 
 import ZapsIcon from "../assets/icon-4.svg";
 import WalletIcon from "../assets/wallet.svg";
@@ -132,6 +133,7 @@ function TransferScreen() {
 
   // Recipient search state
   const [searchResults, setSearchResults] = useState<ZapsUser[]>([]);
+  const [recentRecipients, setRecentRecipients] = useState<string[]>([]);
   const [searching, setSearching] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -175,6 +177,13 @@ function TransferScreen() {
     setRecipient(user.username);
     setSearchResults([]);
     setShowDropdown(false);
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const cached = await getRecentRecipients();
+      setRecentRecipients(cached);
+    })();
   }, []);
 
   const token = TOKENS.find((t) => t.id === selectedToken) || TOKENS[0];
@@ -266,6 +275,7 @@ function TransferScreen() {
           hash: result.hash,
         });
         await AsyncStorage.setItem("pending_transfers", JSON.stringify(list));
+        await saveRecentRecipient(recipient);
       } catch (e) {
         Alert.alert("Transfer Failed", (e as Error).message);
         setSubmitting(false);
@@ -379,6 +389,39 @@ function TransferScreen() {
                       <Text style={styles.dropdownAddress} numberOfLines={1}>
                         {user.address.slice(0, 10)}…{user.address.slice(-6)}
                       </Text>
+                    </View>
+                    <Ionicons
+                      name="chevron-forward"
+                      size={16}
+                      color="#BDBDBD"
+                    />
+                  </TouchableOpacity>
+                ))}
+              </View>
+            )}
+          {transferType === "ZAPS" &&
+            recipient.length < 2 &&
+            recentRecipients.length > 0 &&
+            !showDropdown && (
+              <View style={styles.dropdownContainer}>
+                <Text style={styles.dropdownHeader}>Recent contacts</Text>
+                {recentRecipients.map((username) => (
+                  <TouchableOpacity
+                    key={username}
+                    style={styles.dropdownItem}
+                    onPress={() => {
+                      setRecipient(username);
+                      setShowDropdown(false);
+                    }}
+                    activeOpacity={0.75}
+                  >
+                    <View style={styles.dropdownAvatar}>
+                      <Text style={styles.dropdownAvatarText}>
+                        {username.charAt(0).toUpperCase()}
+                      </Text>
+                    </View>
+                    <View style={styles.dropdownInfo}>
+                      <Text style={styles.dropdownUsername}>{username}</Text>
                     </View>
                     <Ionicons
                       name="chevron-forward"
@@ -1211,6 +1254,14 @@ const styles = StyleSheet.create({
     elevation: 6,
     overflow: "hidden",
     zIndex: 20,
+  },
+  dropdownHeader: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    backgroundColor: "#F8F9FA",
+    fontSize: 13,
+    fontFamily: "Outfit_600SemiBold",
+    color: "#555",
   },
   dropdownItem: {
     flexDirection: "row",

--- a/mobileapp/src/services/api.ts
+++ b/mobileapp/src/services/api.ts
@@ -11,6 +11,33 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
   };
 }
 
+const RECENT_RECIPIENTS_KEY = "recent_recipient_usernames";
+const MAX_RECENT_RECIPIENTS = 20;
+
+export async function getRecentRecipients(): Promise<string[]> {
+  try {
+    const raw = await AsyncStorage.getItem(RECENT_RECIPIENTS_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveRecentRecipient(username: string): Promise<void> {
+  if (!username) return;
+  try {
+    const raw = await AsyncStorage.getItem(RECENT_RECIPIENTS_KEY);
+    const current = raw ? (JSON.parse(raw) as string[]) : [];
+    const next = [username, ...current.filter((item) => item !== username)].slice(
+      0,
+      MAX_RECENT_RECIPIENTS
+    );
+    await AsyncStorage.setItem(RECENT_RECIPIENTS_KEY, JSON.stringify(next));
+  } catch {
+    // Ignore cache failures.
+  }
+}
+
 export interface YieldBalance {
   apy: string;
   totalYieldEarned: string;


### PR DESCRIPTION



Checking the mobile app service layer and existing storage usage before adding the cache helper.

Searched for files matching `**/mobileapp/src/services/**`, 8 matches

Searched for regex `AsyncStorage|async-storage|@react-native-async-storage/async-storage|AsyncStorage.getItem|AsyncStorage.setItem` (`**/*.{ts,tsx,js,jsx}`), 26 results

Found the mobile API module; reading it now to add a persistent recipient username cache.

Read [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/src/services/api.ts)

Investigating transfer screen usage so the cache helper integrates where recent usernames are loaded instantly.

Searched for regex `recipient|recent contacts|recentRecipients|recipientUsername|username.*recipient|contacts` (`**/mobileapp/**/*.{ts,tsx,js,jsx}`), 34 results

No matches found. Your search pattern might be excluded completely by either the search.exclude settings or .*ignore files.
If you believe that it should have results, you can check into the .*ignore files and the exclude setting (here are some excluded patterns for reference:[**/node_modules,**/bower_components,**/*.code-search]).
Then if you want to include those files you can call the tool again by setting "includeIgnoredFiles" to true.

Reading the transfer screen implementation to wire cached contacts into the existing recipient search flow.

Read [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/app/transfer.tsx#1-1), lines 1 to 260

Read [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/app/transfer.tsx#260-260), lines 260 to 520

Read [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/app/transfer.tsx#520-520), lines 520 to 1040

Adding a helper layer in api.ts for cached recent recipient usernames and preparing the transfer screen to read it on startup.

Replacing 114 lines with 184 lines in [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/src/services/api.ts), [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/app/transfer.tsx)


```

```

```

```
Checking the updated transfer screen styles and ensuring the new recent contacts dropdown renders cleanly.

Searched for regex `dropdownHeader|dropdownContainer|dropdownItem|dropdownAvatar|dropdownInfo|dropdownUsername|dropdownAddress|searchingIndicator` (`**/mobileapp/app/transfer.tsx`), 23 results

Read [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/app/transfer.tsx#1210-1210), lines 1210 to 1295

Great, the cache helper is in place. Adding the missing dropdown section header style so recent contacts render correctly.

Replacing 27 lines with 35 lines in [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/app/transfer.tsx)
Closes #569 

```

```
Validating the updated files for type or syntax issues before wrapping up.

Checked [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/src/services/api.ts), [](file:///c%3A/Users/Documents/wave/zaps/mobileapp/app/transfer.tsx), no problems found

## Done

- Added `getRecentRecipients()` and `saveRecentRecipient()` to api.ts
- Added local cache loading on transfer screen load
- Added recent contacts dropdown on recipient input
- Limited storage to the 20 most recent recipient usernames
- Verified no file errors in api.ts and transfer.tsx

If you want, I can also add a small unit test or further optimize the dropdown behavior.

Made changes.

Description\nUse local persistent storage caches storing historical recipient usernames.\n\n## Files to Edit/Create\n- mobileapp/src/services/api.ts (new cache helper)\n\n## Acceptance Criteria\n- Fetch from cache instantly on screen load.
Store up to 20 recent contacts.\n\n## Guidance / Hints\nUse AsyncStorage library integrations to write key pairs.