### PR TITLE
feat(mobile): add batch payout components and rendering tests

### DIFF
--- a/mobileapp/__tests__/BatchPayoutSummary.test.tsx
+++ b/mobileapp/__tests__/BatchPayoutSummary.test.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import BatchPayoutSummary from "../src/components/BatchPayoutSummary";
+import type {
+  BatchPayoutSummary as SummaryType,
+  BatchPayoutItem,
+} from "../src/types/batchPayout";
+
+const baseSummary: SummaryType = {
+  id: "batch-001",
+  totalAmount: "₦45,000.00",
+  currency: "NGN",
+  itemCount: 3,
+  completedCount: 2,
+  failedCount: 0,
+  createdAt: "2026-07-20T10:00:00Z",
+};
+
+const baseItems: BatchPayoutItem[] = [
+  {
+    id: "item-1",
+    recipientName: "Alice Johnson",
+    recipientAddress: "GABC1234...",
+    amount: "₦10,000.00",
+    currency: "NGN",
+    status: "completed",
+  },
+  {
+    id: "item-2",
+    recipientName: "Bob Smith",
+    recipientAddress: "GDEF5678...",
+    amount: "₦15,000.00",
+    currency: "NGN",
+    status: "completed",
+  },
+  {
+    id: "item-3",
+    recipientName: "Carol White",
+    recipientAddress: "GHIJ9012...",
+    amount: "₦20,000.00",
+    currency: "NGN",
+    status: "pending",
+  },
+];
+
+describe("BatchPayoutSummary", () => {
+  it("renders total amount and item count", () => {
+    const { getByText } = render(
+      <BatchPayoutSummary summary={baseSummary} items={baseItems} />
+    );
+
+    expect(getByText("₦45,000.00 NGN")).toBeTruthy();
+    expect(getByText("3 items")).toBeTruthy();
+  });
+
+  it("renders completed and failed counts", () => {
+    const { getByText } = render(
+      <BatchPayoutSummary summary={baseSummary} items={baseItems} />
+    );
+
+    expect(getByText("2 completed")).toBeTruthy();
+    expect(getByText("1 pending")).toBeTruthy();
+  });
+
+  it("renders all item rows", () => {
+    const { getByText } = render(
+      <BatchPayoutSummary summary={baseSummary} items={baseItems} />
+    );
+
+    expect(getByText("Alice Johnson")).toBeTruthy();
+    expect(getByText("Bob Smith")).toBeTruthy();
+    expect(getByText("Carol White")).toBeTruthy();
+  });
+
+  it("shows correct status badges for pending, completed, and failed items", () => {
+    const mixedItems: BatchPayoutItem[] = [
+      { ...baseItems[0], status: "completed" },
+      { ...baseItems[1], status: "failed" },
+      { ...baseItems[2], status: "pending" },
+    ];
+    const summary = { ...baseSummary, completedCount: 1, failedCount: 1 };
+
+    const { getByText } = render(
+      <BatchPayoutSummary summary={summary} items={mixedItems} />
+    );
+
+    expect(getByText("Completed")).toBeTruthy();
+    expect(getByText("Failed")).toBeTruthy();
+    expect(getByText("Pending")).toBeTruthy();
+  });
+
+  it("handles empty items list", () => {
+    const { getByText } = render(
+      <BatchPayoutSummary summary={{ ...baseSummary, itemCount: 0, completedCount: 0 }} items={[]} />
+    );
+
+    expect(getByText("No payout items")).toBeTruthy();
+  });
+
+  it("handles all-completed state", () => {
+    const summary: SummaryType = {
+      ...baseSummary,
+      completedCount: 3,
+      failedCount: 0,
+    };
+
+    const { getByText, queryByText } = render(
+      <BatchPayoutSummary summary={summary} items={baseItems} />
+    );
+
+    expect(getByText("3 completed")).toBeTruthy();
+    expect(queryByText("failed")).toBeNull();
+    expect(queryByText("pending")).toBeNull();
+  });
+
+  it("handles all-failed state", () => {
+    const summary: SummaryType = {
+      ...baseSummary,
+      completedCount: 0,
+      failedCount: 3,
+    };
+    const failedItems = baseItems.map((i) => ({ ...i, status: "failed" as const }));
+
+    const { getByText, queryByText } = render(
+      <BatchPayoutSummary summary={summary} items={failedItems} />
+    );
+
+    expect(getByText("3 failed")).toBeTruthy();
+    expect(queryByText("completed")).toBeNull();
+  });
+
+  it("renders singular 'item' label for single item", () => {
+    const summary: SummaryType = {
+      ...baseSummary,
+      itemCount: 1,
+      completedCount: 1,
+      failedCount: 0,
+    };
+
+    const { getByText } = render(
+      <BatchPayoutSummary summary={summary} items={[baseItems[0]]} />
+    );
+
+    expect(getByText("1 item")).toBeTruthy();
+  });
+});

--- a/mobileapp/src/components/BatchPayoutItemRow.tsx
+++ b/mobileapp/src/components/BatchPayoutItemRow.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { COLORS } from "../constants/colors";
+import type { BatchPayoutItem } from "../types/batchPayout";
+
+const STATUS_STYLES: Record<
+  BatchPayoutItem["status"],
+  { bg: string; text: string; label: string }
+> = {
+  pending: { bg: "#FEF3C7", text: "#92400E", label: "Pending" },
+  completed: { bg: "#D1FAE5", text: "#065F46", label: "Completed" },
+  failed: { bg: "#FEE2E2", text: "#991B1B", label: "Failed" },
+};
+
+export default function BatchPayoutItemRow({ item }: { item: BatchPayoutItem }) {
+  const status = STATUS_STYLES[item.status];
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.info}>
+        <Text style={styles.name}>{item.recipientName}</Text>
+        <Text style={styles.address}>{item.recipientAddress}</Text>
+      </View>
+      <View style={styles.right}>
+        <Text style={styles.amount}>
+          {item.amount} {item.currency}
+        </Text>
+        <View style={[styles.badge, { backgroundColor: status.bg }]}>
+          <Text style={[styles.badgeText, { color: status.text }]}>
+            {status.label}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#E5E7EB",
+  },
+  info: {
+    flex: 1,
+    marginRight: 12,
+  },
+  name: {
+    fontSize: 15,
+    fontFamily: "Outfit_600SemiBold",
+    color: COLORS.black,
+    marginBottom: 2,
+  },
+  address: {
+    fontSize: 12,
+    fontFamily: "Outfit_400Regular",
+    color: "#6B7280",
+  },
+  right: {
+    alignItems: "flex-end",
+  },
+  amount: {
+    fontSize: 15,
+    fontFamily: "Outfit_700Bold",
+    color: COLORS.black,
+    marginBottom: 4,
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontFamily: "Outfit_500Medium",
+  },
+});

--- a/mobileapp/src/components/BatchPayoutSummary.tsx
+++ b/mobileapp/src/components/BatchPayoutSummary.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { COLORS } from "../constants/colors";
+import type {
+  BatchPayoutSummary as BatchPayoutSummaryType,
+  BatchPayoutItem,
+} from "../types/batchPayout";
+import BatchPayoutItemRow from "./BatchPayoutItemRow";
+
+interface Props {
+  summary: BatchPayoutSummaryType;
+  items: BatchPayoutItem[];
+}
+
+export default function BatchPayoutSummary({ summary, items }: Props) {
+  const pendingCount = summary.itemCount - summary.completedCount - summary.failedCount;
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Batch Payout</Text>
+
+      <Text style={styles.totalAmount}>
+        {summary.totalAmount} {summary.currency}
+      </Text>
+
+      <View style={styles.statsRow}>
+        <Text style={styles.stat}>
+          {summary.itemCount} item{summary.itemCount !== 1 ? "s" : ""}
+        </Text>
+        <Text style={[styles.stat, styles.completedStat]}>
+          {summary.completedCount} completed
+        </Text>
+        {summary.failedCount > 0 && (
+          <Text style={[styles.stat, styles.failedStat]}>
+            {summary.failedCount} failed
+          </Text>
+        )}
+        {pendingCount > 0 && (
+          <Text style={[styles.stat, styles.pendingStat]}>
+            {pendingCount} pending
+          </Text>
+        )}
+      </View>
+
+      <View style={styles.list}>
+        {items.length === 0 ? (
+          <Text style={styles.emptyText}>No payout items</Text>
+        ) : (
+          items.map((item) => (
+            <BatchPayoutItemRow key={item.id} item={item} />
+          ))
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: COLORS.white,
+    borderRadius: 22,
+    padding: 18,
+  },
+  title: {
+    fontSize: 13,
+    fontFamily: "Outfit_500Medium",
+    color: "#6B7280",
+    marginBottom: 6,
+  },
+  totalAmount: {
+    fontSize: 24,
+    fontFamily: "Outfit_700Bold",
+    color: COLORS.black,
+    marginBottom: 8,
+  },
+  statsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+    marginBottom: 16,
+  },
+  stat: {
+    fontSize: 12,
+    fontFamily: "Outfit_500Medium",
+    color: "#6B7280",
+  },
+  completedStat: {
+    color: "#065F46",
+  },
+  failedStat: {
+    color: "#991B1B",
+  },
+  pendingStat: {
+    color: "#92400E",
+  },
+  list: {
+    borderTopWidth: 1,
+    borderTopColor: "#E5E7EB",
+    paddingTop: 4,
+  },
+  emptyText: {
+    fontSize: 14,
+    fontFamily: "Outfit_400Regular",
+    color: "#9CA3AF",
+    textAlign: "center",
+    paddingVertical: 20,
+  },
+});

--- a/mobileapp/src/types/batchPayout.ts
+++ b/mobileapp/src/types/batchPayout.ts
@@ -1,0 +1,18 @@
+export interface BatchPayoutItem {
+  id: string;
+  recipientName: string;
+  recipientAddress: string;
+  amount: string;
+  currency: string;
+  status: 'pending' | 'completed' | 'failed';
+}
+
+export interface BatchPayoutSummary {
+  id: string;
+  totalAmount: string;
+  currency: string;
+  itemCount: number;
+  completedCount: number;
+  failedCount: number;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

Adds batch payout summary and item row components for the mobile app, along with comprehensive rendering tests.

## Changes

### New files
- **`mobileapp/src/types/batchPayout.ts`** — `BatchPayoutItem` and `BatchPayoutSummary` interfaces
- **`mobileapp/src/components/BatchPayoutItemRow.tsx`** — Single payout row with recipient name, address, amount, and color-coded status badge (pending=yellow, completed=green, failed=red)
- **`mobileapp/src/components/BatchPayoutSummary.tsx`** — Summary card showing total amount, item/completed/failed/pending counts, and renders item rows (with empty state)
- **`mobileapp/__tests__/BatchPayoutSummary.test.tsx`** — 8 rendering tests

### Test coverage
- Renders total amount and item count
- Renders completed and failed counts
- Renders all item rows
- Shows correct status badges for each status
- Handles empty items list
- Handles all-completed state
- Handles all-failed state
- Uses singular "item" label for single item

Fixes #581