### PR TITLE
feat: add transfer confirmation screen before signing (#565)

### DIFF
--- a/mobileapp/__tests__/Avatar.test.tsx
+++ b/mobileapp/__tests__/Avatar.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { Avatar } from "../src/components/Avatar";
+
+describe("Avatar", () => {
+  it("renders initials when no uri is provided", () => {
+    const { getByText } = render(<Avatar name="tolu" />);
+    expect(getByText("T")).toBeTruthy();
+  });
+
+  it("renders two initials for multi-word names", () => {
+    const { getByText } = render(<Avatar name="john doe" />);
+    expect(getByText("JD")).toBeTruthy();
+  });
+
+  it("renders fallback character for single-character names", () => {
+    const { getByText } = render(<Avatar name="x" />);
+    expect(getByText("X")).toBeTruthy();
+  });
+
+  it("renders image when uri is provided", () => {
+    const { getByLabelText } = render(
+      <Avatar uri="https://example.com/avatar.jpg" name="tolu.zaps" />
+    );
+    expect(getByLabelText("Avatar for tolu.zaps")).toBeTruthy();
+  });
+
+  it("renders initials fallback with accessibility label", () => {
+    const { getByLabelText } = render(<Avatar name="tolu.zaps" />);
+    expect(getByLabelText("Avatar placeholder for tolu.zaps")).toBeTruthy();
+  });
+});

--- a/mobileapp/__tests__/TransferConfirmationCard.test.tsx
+++ b/mobileapp/__tests__/TransferConfirmationCard.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { TransferConfirmationCard } from "../src/components/TransferConfirmationCard";
+
+const mockRecipient = {
+  username: "tolu.zaps",
+  address: "GABC1234567890DEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+  avatar_url: null as string | null,
+};
+
+describe("TransferConfirmationCard", () => {
+  it("renders recipient username", () => {
+    const { getByText } = render(
+      <TransferConfirmationCard
+        recipient={mockRecipient}
+        amount="500"
+        tokenSymbol="XLM"
+      />
+    );
+    expect(getByText("tolu.zaps")).toBeTruthy();
+  });
+
+  it("renders truncated address", () => {
+    const { getByText } = render(
+      <TransferConfirmationCard
+        recipient={mockRecipient}
+        amount="500"
+        tokenSymbol="XLM"
+      />
+    );
+    expect(getByText(/GABC123456/)).toBeTruthy();
+    expect(getByText(/7890AB/)).toBeTruthy();
+  });
+
+  it("renders amount with token symbol", () => {
+    const { getByText } = render(
+      <TransferConfirmationCard
+        recipient={mockRecipient}
+        amount="500"
+        tokenSymbol="XLM"
+      />
+    );
+    expect(getByText("500 XLM")).toBeTruthy();
+  });
+
+  it("renders description when provided", () => {
+    const { getByText } = render(
+      <TransferConfirmationCard
+        recipient={mockRecipient}
+        amount="500"
+        tokenSymbol="XLM"
+        description="Lunch money"
+      />
+    );
+    expect(getByText("Lunch money")).toBeTruthy();
+  });
+
+  it("renders 'No note' when description is empty", () => {
+    const { getByText } = render(
+      <TransferConfirmationCard
+        recipient={mockRecipient}
+        amount="500"
+        tokenSymbol="XLM"
+      />
+    );
+    expect(getByText("No note")).toBeTruthy();
+  });
+
+  it("does not render verification badge for non-verified recipient", () => {
+    const { queryByLabelText } = render(
+      <TransferConfirmationCard
+        recipient={mockRecipient}
+        amount="500"
+        tokenSymbol="XLM"
+      />
+    );
+    expect(queryByLabelText("Verified recipient")).toBeNull();
+  });
+
+  it("renders verification badge for verified recipient", () => {
+    const { getByLabelText } = render(
+      <TransferConfirmationCard
+        recipient={{ ...mockRecipient, isVerified: true }}
+        amount="500"
+        tokenSymbol="XLM"
+      />
+    );
+    expect(getByLabelText("Verified recipient")).toBeTruthy();
+  });
+
+  it("renders avatar with fallback initials when no avatar_url", () => {
+    const { getByLabelText } = render(
+      <TransferConfirmationCard
+        recipient={mockRecipient}
+        amount="500"
+        tokenSymbol="XLM"
+      />
+    );
+    expect(getByLabelText("Avatar placeholder for tolu.zaps")).toBeTruthy();
+  });
+
+  it("renders avatar with image when avatar_url is provided", () => {
+    const { getByLabelText } = render(
+      <TransferConfirmationCard
+        recipient={{ ...mockRecipient, avatar_url: "https://example.com/a.jpg" }}
+        amount="500"
+        tokenSymbol="XLM"
+      />
+    );
+    expect(getByLabelText("Avatar for tolu.zaps")).toBeTruthy();
+  });
+});

--- a/mobileapp/__tests__/VerificationBadge.test.tsx
+++ b/mobileapp/__tests__/VerificationBadge.test.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { VerificationBadge } from "../src/components/VerificationBadge";
+
+describe("VerificationBadge", () => {
+  it("renders with accessible label", () => {
+    const { getByLabelText } = render(<VerificationBadge />);
+    expect(getByLabelText("Verified recipient")).toBeTruthy();
+  });
+
+  it("renders with custom size", () => {
+    const { getByLabelText } = render(<VerificationBadge size={24} />);
+    expect(getByLabelText("Verified recipient")).toBeTruthy();
+  });
+});

--- a/mobileapp/app/transfer.tsx
+++ b/mobileapp/app/transfer.tsx
@@ -19,6 +19,8 @@ import { COLORS } from "../src/constants/colors";
 import { Button } from "../src/components/Button";
 import { Input } from "../src/components/Input";
 import { AccountTypeCard } from "../src/components/AccountTypeCard";
+import { TransferConfirmationCard } from "../src/components/TransferConfirmationCard";
+import type { ZapsUser } from "../src/types/user";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   checkFreighter,
@@ -105,11 +107,7 @@ const API_BASE =
   (typeof process !== "undefined" && process.env?.EXPO_PUBLIC_API_URL) ||
   "http://localhost:8080";
 
-interface ZapsUser {
-  username: string;
-  address: string;
-  avatar_url: string | null;
-}
+
 
 function TransferScreen() {
   const router = useRouter();
@@ -134,6 +132,7 @@ function TransferScreen() {
   const [searchResults, setSearchResults] = useState<ZapsUser[]>([]);
   const [searching, setSearching] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<ZapsUser | null>(null);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const searchUsers = useCallback(async (query: string) => {
@@ -173,6 +172,7 @@ function TransferScreen() {
 
   const handleSelectUser = useCallback((user: ZapsUser) => {
     setRecipient(user.username);
+    setSelectedUser(user);
     setSearchResults([]);
     setShowDropdown(false);
   }, []);
@@ -237,9 +237,15 @@ function TransferScreen() {
   const handleNext = async () => {
     if (step === 2) {
       if (!walletState?.isConnected) {
-        setStep(4);
+        setStep(5);
         return;
       }
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+      setStep(3);
+      return;
+    }
+
+    if (step === 3) {
       setSubmitting(true);
       try {
         const assetIssuer =
@@ -249,8 +255,8 @@ function TransferScreen() {
         const result = await submitPayment(
           recipient,
           amount,
-          walletState.source!,
-          walletState.publicKey,
+          walletState!.source!,
+          walletState!.publicKey,
           token.symbol,
           assetIssuer,
           description || undefined
@@ -272,9 +278,12 @@ function TransferScreen() {
         return;
       }
       setSubmitting(false);
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+      setStep(4);
+      return;
     }
 
-    if (step === 3) {
+    if (step === 4) {
       router.replace("/(personal)/home");
       return;
     }
@@ -286,11 +295,11 @@ function TransferScreen() {
   const handleBack = () => {
     if (step === 0) {
       router.back();
-    } else if (step === 3) {
-      router.replace("/(personal)/home");
     } else if (step === 4) {
+      router.replace("/(personal)/home");
+    } else if (step === 5) {
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-      setStep(2);
+      setStep(3);
     } else {
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
       setStep(step - 1);
@@ -299,7 +308,7 @@ function TransferScreen() {
 
   const handleDisconnect = async () => {
     setWalletState(null);
-    setStep(2);
+    setStep(3);
   };
 
   const renderStep0 = () => (
@@ -338,6 +347,7 @@ function TransferScreen() {
             value={recipient}
             onChangeText={(text: string) => {
               setRecipient(text);
+              setSelectedUser(null);
               if (transferType !== "ZAPS") return;
               if (text.length < 2) {
                 setShowDropdown(false);
@@ -605,7 +615,40 @@ function TransferScreen() {
     </View>
   );
 
-  const renderStep3 = () => (
+  const renderStep3 = () => {
+    const displayUser = selectedUser || {
+      username: recipient,
+      address: "",
+      avatar_url: null as string | null,
+      isVerified: undefined as boolean | undefined,
+    };
+
+    return (
+      <View style={styles.stepContainer}>
+        <Text style={styles.subtitle}>
+          Review the details below before sending.
+        </Text>
+
+        <TransferConfirmationCard
+          recipient={displayUser}
+          amount={amount}
+          tokenSymbol={token.symbol}
+          description={description}
+        />
+
+        <View style={styles.confirmationActions}>
+          <Button
+            title="Go Back"
+            onPress={handleBack}
+            variant="outline"
+            style={styles.goBackButton}
+          />
+        </View>
+      </View>
+    );
+  };
+
+  const renderStep4 = () => (
     <View style={[styles.stepContainer, styles.centerContent]}>
       <View style={styles.successOuter}>
         <View
@@ -633,7 +676,7 @@ function TransferScreen() {
     </View>
   );
 
-  const renderStep4 = () => (
+  const renderStep5 = () => (
     <View style={styles.stepContainer}>
       <Text style={styles.subtitle}>
         Connect a Stellar wallet to authorize this transfer.
@@ -658,8 +701,7 @@ function TransferScreen() {
             <Button
               title="Continue with this wallet"
               onPress={() => {
-                setStep(2);
-                handleNext();
+                setStep(3);
               }}
               loading={submitting}
               style={{ backgroundColor: "#1A4B4A", marginTop: 16 }}
@@ -733,19 +775,23 @@ function TransferScreen() {
     <SafeAreaView style={styles.container}>
       <Stack.Screen options={{ headerShown: false }} />
 
-      {step < 3 && step !== 4 && (
+      {step !== 5 && step !== 4 && (
         <View style={styles.header}>
           <TouchableOpacity onPress={handleBack} style={styles.backButton}>
             <Ionicons name="arrow-back" size={24} color={COLORS.black} />
           </TouchableOpacity>
           <Text style={styles.headerTitle}>
-            {step === 2 ? "Summary & confirmation" : "Social Transfer"}
+            {step === 2
+              ? "Summary"
+              : step === 3
+                ? "Confirm Transfer"
+                : "Social Transfer"}
           </Text>
           <View style={{ width: 40 }} />
         </View>
       )}
 
-      {step === 4 && (
+      {step === 5 && (
         <View style={styles.header}>
           <TouchableOpacity onPress={handleBack} style={styles.backButton}>
             <Ionicons name="arrow-back" size={24} color={COLORS.black} />
@@ -758,7 +804,7 @@ function TransferScreen() {
       <ScrollView
         contentContainerStyle={[
           styles.scrollContent,
-          (step === 3 || step === 4) && { justifyContent: "center" },
+          (step === 4 || step === 5) && { justifyContent: "center" },
         ]}
         showsVerticalScrollIndicator={false}
       >
@@ -767,29 +813,31 @@ function TransferScreen() {
         {step === 2 && renderStep2()}
         {step === 3 && renderStep3()}
         {step === 4 && renderStep4()}
+        {step === 5 && renderStep5()}
       </ScrollView>
 
-      {step !== 4 && (
+      {step !== 5 && step !== 4 && (
         <View style={styles.footer}>
           <Button
             title={
               step === 1
                 ? "Review"
                 : step === 2
-                  ? submitting
-                    ? "Submitting..."
-                    : "Confirm & Pay"
+                  ? "Continue"
                   : step === 3
-                    ? "Done"
-                    : "Continue"
+                    ? submitting
+                      ? "Sending..."
+                      : "Send"
+                    : step === 4
+                      ? "Done"
+                      : "Continue"
             }
             onPress={handleNext}
-            loading={submitting}
+            loading={step !== 3 && submitting}
             disabled={
               (step === 0 && !transferType) ||
               (step === 1 && (!recipient || !amount)) ||
-              (step === 2 && false) ||
-              (step === 3 && false) ||
+              (step === 3 && submitting) ||
               submitting
             }
             style={{ backgroundColor: "#1A4B4A" }}
@@ -1247,6 +1295,14 @@ const styles = StyleSheet.create({
     fontFamily: "Outfit_400Regular",
     color: "#999",
     marginTop: 2,
+  },
+
+  // ── Confirmation step ─────────────────────────────────────────────────────
+  confirmationActions: {
+    marginTop: 24,
+  },
+  goBackButton: {
+    borderColor: "#E0E0E0",
   },
 });
 

--- a/mobileapp/src/components/Avatar.tsx
+++ b/mobileapp/src/components/Avatar.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { View, Text, Image, StyleSheet } from "react-native";
+import { COLORS } from "../constants/colors";
+
+interface AvatarProps {
+  uri?: string | null;
+  name: string;
+  size?: number;
+}
+
+export const Avatar = React.memo(function Avatar({
+  uri,
+  name,
+  size = 64,
+}: AvatarProps) {
+  const initials = name
+    .split(/[\s._-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w.charAt(0).toUpperCase())
+    .join("");
+
+  const fontSize = Math.round(size * 0.38);
+
+  if (uri) {
+    return (
+      <Image
+        source={{ uri }}
+        style={[styles.image, { width: size, height: size, borderRadius: size / 2 }]}
+        accessibilityLabel={`Avatar for ${name}`}
+      />
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.fallback,
+        { width: size, height: size, borderRadius: size / 2 },
+      ]}
+      accessibilityLabel={`Avatar placeholder for ${name}`}
+    >
+      <Text style={[styles.initials, { fontSize }]}>
+        {initials || "?"}
+      </Text>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  image: {
+    backgroundColor: COLORS.gray,
+  },
+  fallback: {
+    backgroundColor: COLORS.primary,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  initials: {
+    fontFamily: "Outfit_700Bold",
+    color: COLORS.secondary,
+  },
+});

--- a/mobileapp/src/components/TransferConfirmationCard.tsx
+++ b/mobileapp/src/components/TransferConfirmationCard.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { COLORS } from "../constants/colors";
+import { Avatar } from "./Avatar";
+import { VerificationBadge } from "./VerificationBadge";
+import type { ZapsUser } from "../types/user";
+
+interface TransferConfirmationCardProps {
+  recipient: ZapsUser;
+  amount: string;
+  tokenSymbol: string;
+  description?: string;
+}
+
+export const TransferConfirmationCard = React.memo(
+  function TransferConfirmationCard({
+    recipient,
+    amount,
+    tokenSymbol,
+    description,
+  }: TransferConfirmationCardProps) {
+    return (
+      <View style={styles.card}>
+        <Avatar uri={recipient.avatar_url} name={recipient.username} size={80} />
+
+        <View style={styles.nameRow}>
+          <Text style={styles.username}>{recipient.username}</Text>
+          {recipient.isVerified && <VerificationBadge />}
+        </View>
+
+        {recipient.address && (
+          <Text style={styles.address} numberOfLines={1}>
+            {recipient.address.slice(0, 10)}...{recipient.address.slice(-6)}
+          </Text>
+        )}
+
+        <View style={styles.divider} />
+
+        <View style={styles.detailsSection}>
+          <View style={styles.detailRow}>
+            <View style={styles.detailIcon}>
+              <Ionicons name="cash-outline" size={18} color="#777" />
+            </View>
+            <View style={styles.detailCol}>
+              <Text style={styles.detailLabel}>Amount</Text>
+              <Text style={styles.detailValue}>
+                {amount} {tokenSymbol}
+              </Text>
+            </View>
+          </View>
+
+          <View style={[styles.detailRow, { marginTop: 16 }]}>
+            <View style={styles.detailIcon}>
+              <Ionicons name="chatbubble-outline" size={18} color="#777" />
+            </View>
+            <View style={styles.detailCol}>
+              <Text style={styles.detailLabel}>Note</Text>
+              <Text style={styles.detailValue}>{description || "No note"}</Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: COLORS.white,
+    borderRadius: 24,
+    padding: 24,
+    borderWidth: 1,
+    borderColor: "#F0F0F0",
+    alignItems: "center",
+  },
+  nameRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 16,
+  },
+  username: {
+    fontSize: 20,
+    fontFamily: "Outfit_700Bold",
+    color: COLORS.black,
+  },
+  address: {
+    fontSize: 13,
+    fontFamily: "Outfit_400Regular",
+    color: "#999",
+    marginTop: 4,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "#F0F0F0",
+    width: "100%",
+    marginVertical: 20,
+  },
+  detailsSection: {
+    width: "100%",
+  },
+  detailRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  detailIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: "#F5F5F5",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 12,
+  },
+  detailCol: {
+    flex: 1,
+  },
+  detailLabel: {
+    fontSize: 12,
+    fontFamily: "Outfit_400Regular",
+    color: "#999",
+  },
+  detailValue: {
+    fontSize: 15,
+    fontFamily: "Outfit_600SemiBold",
+    color: COLORS.black,
+    marginTop: 2,
+  },
+});

--- a/mobileapp/src/components/VerificationBadge.tsx
+++ b/mobileapp/src/components/VerificationBadge.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { COLORS } from "../constants/colors";
+
+interface VerificationBadgeProps {
+  size?: number;
+}
+
+export const VerificationBadge = React.memo(function VerificationBadge({
+  size = 18,
+}: VerificationBadgeProps) {
+  return (
+    <View
+      style={[styles.badge, { width: size, height: size, borderRadius: size / 2 }]}
+      accessibilityLabel="Verified recipient"
+      accessibilityRole="text"
+    >
+      <Ionicons name="shield-checkmark" size={Math.round(size * 0.7)} color={COLORS.white} />
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  badge: {
+    backgroundColor: COLORS.primary,
+    justifyContent: "center",
+    alignItems: "center",
+    marginLeft: 4,
+  },
+});

--- a/mobileapp/src/types/user.ts
+++ b/mobileapp/src/types/user.ts
@@ -1,0 +1,7 @@
+export interface ZapsUser {
+  username: string;
+  address: string;
+  avatar_url: string | null;
+  /** Placeholder — real trust data needs to be wired in by the API layer. */
+  isVerified?: boolean;
+}


### PR DESCRIPTION
## Summary

closes #565: adds a confirmation screen showing recipient avatar, username, and verification status before a transfer is signed and submitted.

Previously, `transfer.tsx` went straight from the transfer summary to calling `submitPayment`. This adds a review step in between so the sender sees exactly who they're paying before signing.

## Changes

**New components**
- `Avatar.tsx` - renders a recipient's avatar image when a URI is  available, falls back to an initials-based circle otherwise
- `VerificationBadge.tsx` - small badge shown only when a recipient is  verified
- `TransferConfirmationCard.tsx` - the confirmation card itself: avatar,  name + badge, truncated address, amount, token, note

**New type**
- `src/types/user.ts` - `ZapsUser` interface with an optional  `isVerified?: boolean` field

**Modified**
- `app/transfer.tsx` - inserts a new confirmation step between the  transfer summary and submission

## Flow change

Step sequence changed from `0 → 1 → 2 → submit → 3` to`0 → 1 → 2 → 3 (confirm) → 4 (success)`, with wallet connection at step 5:
- **Step 2 (Summary)** - "Continue" now routes to step 3 if a wallet is  already connected, or to step 5 (wallet connect) if not
- **Step 3 (Confirm Transfer)** -shows the new confirmation card; "Send" calls `submitPayment`, "Go Back" returns to step 2
- **Step 5 (Wallet Connect)** - "Continue with this wallet" now goes to  step 3, not directly to submission `submitPayment` is only ever called from step 3 now.

## Design notes

- Matched the existing `COLORS` + `StyleSheet.create` convention already  used in `transfer.tsx`, `Button`, `Input`, and `AccountTypeCard` - did  not use the `useTheme()`/`ThemedText`/`Spacing` system, since that  belongs to the separate merchant flow (`app/merchant/*`) and is built around `theme.ts`'s light/dark color system, a different convention  from the rest of this screen.
- No existing trust/verification field was found anywhere in the type system. Added `isVerified?: boolean` as an optional placeholder on  `ZapsUser`, defaulting to falsy. `VerificationBadge` only renders when  `isVerified === true`. **Real trust/verification data still needs to be  wired in from the API layer** - this PR only builds the UI contract for  it.

## Tests

- `Avatar.test.tsx` -5 tests
- `VerificationBadge.test.tsx` -2 tests
- `TransferConfirmationCard.test.tsx` - 9 tests, including badge  visibility for verified vs. unverified recipients

## Checklist

- [x] Lint clean
- [x] Typecheck clean (no new errors; pre-existing SVG module-resolution
  warnings in `transfer.tsx` are unchanged by this PR)
- [x] 19/19 tests passing across 4 suites
- [ ] Real recipient verification data source -follow-up, not in scope here