### PR TITLE
feat(mobileapp): Add Auto-Earn on Idle Funds toggle with description modal (#574)

### DIFF
--- a/mobileapp/app/(personal)/home.tsx
+++ b/mobileapp/app/(personal)/home.tsx
@@ -146,6 +146,7 @@ export default function HomeScreen() {
   const [autoYieldEnabled, setAutoYieldEnabled] = useState(true);
   const [autoEarnSyncing, setAutoEarnSyncing] = useState(false);
   const [autoEarnTooltipVisible, setAutoEarnTooltipVisible] = useState(false);
+  const [autoEarnDescModalVisible, setAutoEarnDescModalVisible] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const earningsSheetTranslateY = useRef(new Animated.Value(48)).current;
   const earningsBackdropOpacity = useRef(new Animated.Value(0)).current;
@@ -504,6 +505,17 @@ export default function HomeScreen() {
     setAutoEarnTooltipVisible((prev) => !prev);
   };
 
+  const openAutoEarnDescModal = () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+      () => undefined
+    );
+    setAutoEarnDescModalVisible(true);
+  };
+
+  const closeAutoEarnDescModal = () => {
+    setAutoEarnDescModalVisible(false);
+  };
+
   const handleYieldRetry = () => {
     setYieldRetryCount((prev) => prev + 1);
     shimmerAnim.setValue(-1);
@@ -806,9 +818,9 @@ export default function HomeScreen() {
                   Auto-Earn on Idle Funds
                 </Text>
                 <TouchableOpacity
-                  onPress={toggleAutoEarnTooltip}
+                  onPress={openAutoEarnDescModal}
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  accessibilityLabel="What is Auto-Earn?"
+                  accessibilityLabel="Learn about Auto-Earn"
                   accessibilityRole="button"
                 >
                   <Ionicons
@@ -819,7 +831,9 @@ export default function HomeScreen() {
                 </TouchableOpacity>
               </View>
               <Text style={styles.autoEarnCardSubtitle}>
-                Sweep idle balance into yield automatically
+                {autoYieldEnabled
+                  ? "Idle balance is actively earning yield"
+                  : "Enable to sweep idle balance into yield"}
               </Text>
             </View>
             <Switch
@@ -828,19 +842,14 @@ export default function HomeScreen() {
               disabled={autoEarnSyncing}
               trackColor={{ false: "#E2E8F0", true: "#34D399" }}
               thumbColor={COLORS.white}
+              accessibilityLabel="Toggle Auto-Earn on Idle Funds"
+              accessibilityRole="switch"
             />
           </View>
-          {autoEarnTooltipVisible && (
-            <View style={styles.autoEarnTooltip}>
-              <Ionicons
-                name="shield-checkmark"
-                size={14}
-                color="#16A34A"
-                style={{ marginRight: 6 }}
-              />
-              <Text style={styles.autoEarnTooltipText}>
-                No DeFi knowledge required.
-              </Text>
+          {autoEarnSyncing && (
+            <View style={styles.autoEarnSyncingRow}>
+              <Ionicons name="sync" size={13} color="#64748B" />
+              <Text style={styles.autoEarnSyncingText}>Saving preference…</Text>
             </View>
           )}
         </View>
@@ -1185,6 +1194,167 @@ export default function HomeScreen() {
         </View>
       </Modal>
 
+      {/* Auto-Earn Description Modal */}
+      <Modal
+        visible={autoEarnDescModalVisible}
+        transparent={true}
+        animationType="fade"
+        onRequestClose={closeAutoEarnDescModal}
+        accessibilityViewIsModal={true}
+      >
+        <View style={styles.autoEarnModalOverlay}>
+          <TouchableOpacity
+            activeOpacity={1}
+            style={StyleSheet.absoluteFill}
+            onPress={closeAutoEarnDescModal}
+            accessibilityLabel="Dismiss"
+          />
+          <View style={styles.autoEarnModalCard}>
+            {/* Header */}
+            <View style={styles.autoEarnModalHeader}>
+              <View style={styles.autoEarnModalIconBadge}>
+                <Ionicons name="flash" size={22} color="#16A34A" />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={styles.autoEarnModalTitle}>
+                  Auto-Earn on Idle Funds
+                </Text>
+                <Text style={styles.autoEarnModalSubtitle}>
+                  How it works
+                </Text>
+              </View>
+              <TouchableOpacity
+                onPress={closeAutoEarnDescModal}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityLabel="Close"
+                accessibilityRole="button"
+              >
+                <Ionicons name="close" size={22} color="#6B7280" />
+              </TouchableOpacity>
+            </View>
+
+            {/* Divider */}
+            <View style={styles.autoEarnModalDivider} />
+
+            {/* Yield rules / description */}
+            <View style={styles.autoEarnModalRulesList}>
+              <View style={styles.autoEarnModalRule}>
+                <View style={styles.autoEarnModalRuleIcon}>
+                  <Ionicons name="swap-horizontal" size={16} color="#1A4B4A" />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.autoEarnModalRuleTitle}>
+                    Automatic sweeping
+                  </Text>
+                  <Text style={styles.autoEarnModalRuleDesc}>
+                    Any idle balance in your Zaps wallet is automatically swept
+                    into a yield vault at the end of each day, so your money
+                    never sits still.
+                  </Text>
+                </View>
+              </View>
+
+              <View style={styles.autoEarnModalRule}>
+                <View style={styles.autoEarnModalRuleIcon}>
+                  <Ionicons name="trending-up" size={16} color="#1A4B4A" />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.autoEarnModalRuleTitle}>
+                    Competitive APY
+                  </Text>
+                  <Text style={styles.autoEarnModalRuleDesc}>
+                    Funds earn yield at the current APY displayed on your
+                    Earning Balance card. Rates are updated in real time based
+                    on on-chain liquidity.
+                  </Text>
+                </View>
+              </View>
+
+              <View style={styles.autoEarnModalRule}>
+                <View style={styles.autoEarnModalRuleIcon}>
+                  <Ionicons name="lock-open-outline" size={16} color="#1A4B4A" />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.autoEarnModalRuleTitle}>
+                    Always accessible
+                  </Text>
+                  <Text style={styles.autoEarnModalRuleDesc}>
+                    Your funds are never locked. When you send a payment or
+                    withdraw, the required amount is swept back to your
+                    available balance instantly.
+                  </Text>
+                </View>
+              </View>
+
+              <View style={styles.autoEarnModalRule}>
+                <View style={styles.autoEarnModalRuleIcon}>
+                  <Ionicons name="shield-checkmark" size={16} color="#1A4B4A" />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.autoEarnModalRuleTitle}>
+                    No DeFi knowledge required
+                  </Text>
+                  <Text style={styles.autoEarnModalRuleDesc}>
+                    Everything is managed automatically. Simply toggle this
+                    setting on and Zaps handles the rest — no wallets, seeds, or
+                    protocols to manage manually.
+                  </Text>
+                </View>
+              </View>
+            </View>
+
+            {/* Divider */}
+            <View style={styles.autoEarnModalDivider} />
+
+            {/* Current status + CTA */}
+            <View style={styles.autoEarnModalFooter}>
+              <View style={styles.autoEarnModalStatusRow}>
+                <View
+                  style={[
+                    styles.autoEarnModalStatusDot,
+                    { backgroundColor: autoYieldEnabled ? "#34D399" : "#CBD5E1" },
+                  ]}
+                />
+                <Text style={styles.autoEarnModalStatusText}>
+                  Auto-Earn is currently{" "}
+                  <Text style={styles.autoEarnModalStatusBold}>
+                    {autoYieldEnabled ? "ON" : "OFF"}
+                  </Text>
+                </Text>
+              </View>
+              <TouchableOpacity
+                style={[
+                  styles.autoEarnModalToggleBtn,
+                  {
+                    backgroundColor: autoYieldEnabled
+                      ? "#FEE2E2"
+                      : COLORS.primary,
+                  },
+                ]}
+                onPress={() => {
+                  void handleAutoYieldToggle(!autoYieldEnabled);
+                  closeAutoEarnDescModal();
+                }}
+                disabled={autoEarnSyncing}
+                accessibilityLabel={
+                  autoYieldEnabled ? "Turn off Auto-Earn" : "Turn on Auto-Earn"
+                }
+                accessibilityRole="button"
+              >
+                <Text
+                  style={[
+                    styles.autoEarnModalToggleBtnText,
+                    { color: autoYieldEnabled ? "#DC2626" : COLORS.secondary },
+                  ]}
+                >
+                  {autoYieldEnabled ? "Turn Off Auto-Earn" : "Turn On Auto-Earn"}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+
       {/* Comments Modal */}
       <Modal
         visible={commentsModalVisible}
@@ -1493,6 +1663,133 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontFamily: "Outfit_500Medium",
     color: "#166534",
+  },
+  autoEarnSyncingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 10,
+    paddingTop: 8,
+    borderTopWidth: 1,
+    borderTopColor: "#F1F5F9",
+  },
+  autoEarnSyncingText: {
+    fontSize: 12,
+    fontFamily: "Outfit_400Regular",
+    color: "#64748B",
+  },
+  // Auto-Earn Description Modal
+  autoEarnModalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.45)",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 20,
+  },
+  autoEarnModalCard: {
+    backgroundColor: COLORS.white,
+    borderRadius: 24,
+    width: "100%",
+    paddingVertical: 20,
+    paddingHorizontal: 20,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 16 },
+    shadowOpacity: 0.15,
+    shadowRadius: 32,
+    elevation: 10,
+  },
+  autoEarnModalHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginBottom: 14,
+  },
+  autoEarnModalIconBadge: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: "#F0FDF4",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  autoEarnModalTitle: {
+    fontSize: 16,
+    fontFamily: "Outfit_700Bold",
+    color: "#111827",
+    lineHeight: 20,
+  },
+  autoEarnModalSubtitle: {
+    fontSize: 13,
+    fontFamily: "Outfit_400Regular",
+    color: "#6B7280",
+    marginTop: 2,
+  },
+  autoEarnModalDivider: {
+    height: 1,
+    backgroundColor: "#F1F5F9",
+    marginVertical: 14,
+  },
+  autoEarnModalRulesList: {
+    gap: 14,
+  },
+  autoEarnModalRule: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  autoEarnModalRuleIcon: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: "#F0FDF4",
+    justifyContent: "center",
+    alignItems: "center",
+    flexShrink: 0,
+    marginTop: 1,
+  },
+  autoEarnModalRuleTitle: {
+    fontSize: 14,
+    fontFamily: "Outfit_600SemiBold",
+    color: "#111827",
+    marginBottom: 3,
+  },
+  autoEarnModalRuleDesc: {
+    fontSize: 13,
+    fontFamily: "Outfit_400Regular",
+    color: "#475569",
+    lineHeight: 19,
+  },
+  autoEarnModalFooter: {
+    gap: 12,
+  },
+  autoEarnModalStatusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  autoEarnModalStatusDot: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+  },
+  autoEarnModalStatusText: {
+    fontSize: 14,
+    fontFamily: "Outfit_500Medium",
+    color: "#374151",
+  },
+  autoEarnModalStatusBold: {
+    fontFamily: "Outfit_700Bold",
+    color: "#111827",
+  },
+  autoEarnModalToggleBtn: {
+    borderRadius: 16,
+    paddingVertical: 13,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  autoEarnModalToggleBtnText: {
+    fontSize: 15,
+    fontFamily: "Outfit_700Bold",
   },
   earningContent: {
     flex: 1,


### PR DESCRIPTION
closes #574

## Summary

Resolves #574

Adds a fully-functional **Auto-Earn on Idle Funds** toggle switch with a proper description modal to `mobileapp/app/(personal)/home.tsx`.

## Changes

### Toggle card (autoEarnCard)
- Info icon (ⓘ) now opens a dedicated description modal instead of an inline tooltip
- Subtitle text is dynamic: reflects current on/off state
- Added `autoEarnSyncingRow` that displays "Saving preference…" with a sync icon while the backend call is in flight

### Auto-Earn Description Modal (new)
- Full-screen fade modal triggered by tapping the ⓘ info icon
- Header: flash icon badge, title "Auto-Earn on Idle Funds", subtitle "How it works", and a close (×) button; tap outside to dismiss
- **Four yield rules** (each with an icon, title, and description):
  1. **Automatic sweeping** – idle balance swept into yield vault daily
  2. **Competitive APY** – real-time rate shown on Earning Balance card
  3. **Always accessible** – funds swept back instantly on spend/withdraw
  4. **No DeFi knowledge required** – fully managed, no seeds/protocols
- Footer: live ON/OFF status dot + label, CTA button ("Turn On / Turn Off Auto-Earn") that calls `updateAutoEarn()` (PATCH `/api/yield/auto-earn`) and closes the modal; button is disabled while syncing

### Backend integration
- Toggle CTA calls existing `updateAutoEarn(boolean)` → PATCH `/api/yield/auto-earn`
- `fetchYieldBalance()` (on mount and pull-to-refresh) seeds `autoYieldEnabled` from `autoEarnEnabled` field

## Acceptance Criteria

| Criterion | Met |
|-----------|-----|
| Click info icon triggers prompt explaining yield rules | ✅ |
| Calls backend endpoint updating settings | ✅ |
| Tooltip widget giving quick definitions | ✅ (full modal with 4 rules) |

## Files Modified

- `mobileapp/app/(personal)/home.tsx`
