### PR TITLE
feat: add warning banners if username is not registered or is blacklisted during transfer

### DIFF
--- a/mobileapp/__tests__/transfer.test.tsx
+++ b/mobileapp/__tests__/transfer.test.tsx
@@ -1,0 +1,368 @@
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock")
+);
+
+import React from "react";
+import { render, waitFor, act, fireEvent } from "@testing-library/react-native";
+import TransferScreenWithBoundary from "../app/transfer";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("expo-router", () => ({
+  useRouter: jest.fn(() => ({
+    back: jest.fn(),
+    replace: jest.fn(),
+  })),
+  Stack: {
+    Screen: () => null,
+  },
+}));
+
+jest.mock("../src/services/stellarWallet", () => ({
+  getLocalKeypair: jest.fn(() => null),
+  checkFreighter: jest.fn(),
+  connectFreighter: jest.fn(),
+  connectAlbedo: jest.fn(),
+  connectLocalWallet: jest.fn(),
+  generateLocalKeypair: jest.fn(),
+  saveLocalKeypair: jest.fn(),
+  submitPayment: jest.fn(),
+}));
+
+jest.mock("../src/services/api", () => ({
+  getRecentRecipients: jest.fn(() => Promise.resolve([])),
+  saveRecentRecipient: jest.fn(),
+}));
+
+// Mock SVG imports
+jest.mock("../assets/icon-4.svg", () => "ZapsIcon");
+jest.mock("../assets/wallet.svg", () => "WalletIcon");
+jest.mock("../assets/XML-logo.svg", () => "XLMLogo");
+jest.mock("../assets/USDT-logo.svg", () => "USDTLogo");
+jest.mock("../assets/USDC-logo.svg", () => "USDCLogo");
+
+// ── Helpers ─────────────────────────────────────────────────────────────────────
+
+/** Advance past step 0 (select transfer type) to step 1 (recipient input). */
+async function advanceToStep1(renderResult: ReturnType<typeof render>) {
+  const { getByText } = renderResult;
+  // Step 0 shows two AccountTypeCards; the "Zaps User" one is already selected
+  // by default (transferType starts as "ZAPS"). Press "Continue".
+  const continueBtn = getByText("Continue");
+  await act(async () => {
+    fireEvent.press(continueBtn);
+  });
+}
+
+/**
+ * Type a recipient username, advance past the debounce timer,
+ * and tap the "1" keypad button to set a non-zero amount.
+ */
+async function typeRecipient(renderResult: ReturnType<typeof render>, username: string) {
+  const { getByPlaceholderText } = renderResult;
+  const input = getByPlaceholderText(/Recipient ZAPS ID/i);
+  await act(async () => {
+    fireEvent.changeText(input, username);
+    // Wait for debounce (350ms) + any pending promises
+    await new Promise((r) => setTimeout(r, 500));
+  });
+
+  // Tap a keypad digit so amount is non-empty (enables the continue button
+  // when there is no warning)
+  await act(async () => {
+    fireEvent.press(renderResult.getByText("1"));
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────────
+
+describe("TransferScreen – Registry Warning Banners", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: search returns empty, resolve returns 404 (not registered)
+    mockFetch.mockReset();
+  });
+
+  // ── 1. "Not registered" warning ────────────────────────────────────────────
+
+  it("shows 'not registered' warning when resolve returns 404", async () => {
+    // Mock the API calls that fire during step 1 recipient typing
+    // Search call (GET /api/users/search) → empty results
+    // Resolve call (GET /api/users/resolve/:username) → 404
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: "username not found" }),
+      });
+
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+    await typeRecipient(renderResult, "unknownuser");
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId("warning-not-registered")).toBeTruthy();
+    });
+
+    // Verify the warning text includes the username
+    expect(
+      renderResult.getByText(/unknownuser is not registered on Zaps/)
+    ).toBeTruthy();
+  });
+
+  it("disables continue button when username is not registered", async () => {
+    // Provide enough state so the button WOULD be enabled otherwise
+    // (recipient + amount filled), then show the warning
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: "username not found" }),
+      });
+
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+    await typeRecipient(renderResult, "ghostuser");
+
+    // Wait for the warning to appear
+    await waitFor(() => {
+      expect(renderResult.getByTestId("warning-not-registered")).toBeTruthy();
+    });
+
+    // The continue button should be disabled
+    // Use getByLabelText (which gets the TouchableOpacity with accessibilityLabel="Review")
+    // instead of getByText (which returns the inner <Text> without accessibilityState).
+    const continueBtn = renderResult.getByLabelText("Review");
+    expect(continueBtn.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  // ── 2. "Blacklisted" warning ───────────────────────────────────────────────
+
+  it("shows 'blacklisted' warning when resolve returns is_blacklisted=true", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          username: "flaggeduser",
+          address: "GABCDEF1234567890XYZ",
+          is_blacklisted: true,
+        }),
+      });
+
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+    await typeRecipient(renderResult, "flaggeduser");
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId("warning-blacklisted")).toBeTruthy();
+    });
+
+    expect(
+      renderResult.getByText(/flaggeduser has been flagged/)
+    ).toBeTruthy();
+  });
+
+  it("disables continue button when username is blacklisted", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          username: "banneduser",
+          address: "GABCDEF1234567890XYZ",
+          is_blacklisted: true,
+        }),
+      });
+
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+    await typeRecipient(renderResult, "banneduser");
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId("warning-blacklisted")).toBeTruthy();
+    });
+
+    const continueBtn = renderResult.getByLabelText("Review");
+    expect(continueBtn.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  // ── 3. "Registered" confirmation (no warning) ──────────────────────────────
+
+  it("shows 'registered' confirmation when resolve returns 200 OK", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [{ username: "existinguser", address: "GXXXX" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          username: "existinguser",
+          address: "GABCDEF1234567890XYZ",
+        }),
+      });
+
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+    await typeRecipient(renderResult, "existinguser");
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId("warning-registered")).toBeTruthy();
+    });
+
+    expect(
+      renderResult.getByText(/existinguser is a registered Zaps user/)
+    ).toBeTruthy();
+  });
+
+  it("enables continue button when username is registered", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [{ username: "validuser", address: "GXXXX" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          username: "validuser",
+          address: "GABCDEF1234567890XYZ",
+        }),
+      });
+
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+    await typeRecipient(renderResult, "validuser");
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId("warning-registered")).toBeTruthy();
+    });
+
+    // The continue button should NOT be disabled for registered users
+    const continueBtn = renderResult.getByLabelText("Review");
+    const state = continueBtn.props.accessibilityState;
+    expect(state?.disabled).not.toBe(true);
+  });
+
+  // ── 4. Edge cases ──────────────────────────────────────────────────────────
+
+  it("shows checking indicator while resolve request is in flight", async () => {
+    // Return a promise that doesn't resolve immediately so we can observe "checking"
+    let resolvePromise!: (value: any) => void;
+    const pendingPromise = new Promise<any>((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    // Mock for the search call (resolves immediately)
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      })
+      // Resolve call stays pending so we can see "checking" state
+      .mockReturnValueOnce(pendingPromise);
+
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+
+    // Type a username — this triggers the debounced resolve call
+    const input = renderResult.getByPlaceholderText(/Recipient ZAPS ID/i);
+    fireEvent.changeText(input, "newuser");
+
+    // Wait for the debounce timer to fire (350ms) + a small buffer
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 500));
+    });
+
+    // The checking banner should be visible while the request is pending
+    expect(renderResult.getByTestId("warning-checking")).toBeTruthy();
+
+    // Resolve the pending request
+    await act(async () => {
+      resolvePromise({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: "username not found" }),
+      });
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Now the "not registered" warning should appear
+    await waitFor(() => {
+      expect(renderResult.getByTestId("warning-not-registered")).toBeTruthy();
+    });
+  });
+
+  it("does not show any warning for external wallet mode", async () => {
+    // Type a recipient — no warning should appear for external wallets
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+    await typeRecipient(renderResult, "someusername");
+
+    // The warning banner condition requires transferType === "ZAPS",
+    // so no testIDs should be present.
+    expect(renderResult.queryByTestId("warning-not-registered")).toBeNull();
+    expect(renderResult.queryByTestId("warning-blacklisted")).toBeNull();
+    expect(renderResult.queryByTestId("warning-registered")).toBeNull();
+  });
+
+  it("clears warning when user edits the recipient field", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: "username not found" }),
+      });
+
+    const renderResult = render(<TransferScreenWithBoundary />);
+    await advanceToStep1(renderResult);
+    await typeRecipient(renderResult, "ghostuser");
+
+    await waitFor(() => {
+      expect(renderResult.getByTestId("warning-not-registered")).toBeTruthy();
+    });
+
+    // Now edit the field — warning should disappear
+    await act(async () => {
+      const input = renderResult.getByPlaceholderText(/Recipient ZAPS ID/i);
+      fireEvent.changeText(input, "ghostuser_edited");
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // The "not registered" warning should be gone (replaced by idle/checking)
+    expect(renderResult.queryByTestId("warning-not-registered")).toBeNull();
+  });
+});

--- a/mobileapp/app/transfer.tsx
+++ b/mobileapp/app/transfer.tsx
@@ -137,6 +137,10 @@ function TransferScreen() {
   const [selectedUser, setSelectedUser] = useState<ZapsUser | null>(null);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Registry check state (not registered / blacklisted warnings)
+  type UsernameStatus = "idle" | "checking" | "registered" | "not_registered" | "blacklisted";
+  const [usernameStatus, setUsernameStatus] = useState<UsernameStatus>("idle");
+
   const searchUsers = useCallback(async (query: string) => {
     if (!query || query.length < 2) {
       setSearchResults([]);
@@ -152,6 +156,9 @@ function TransferScreen() {
       const data: ZapsUser[] = await res.json();
       setSearchResults(data);
       setShowDropdown(data.length > 0);
+
+      // If the search returned no results and the query looks like a full username,
+      // a subsequent resolve call (in the debounce effect) will determine registry status.
     } catch {
       setSearchResults([]);
       setShowDropdown(false);
@@ -160,23 +167,78 @@ function TransferScreen() {
     }
   }, []);
 
-  // Debounce search while user types (ZAPS mode only)
+  /**
+   * Check the registry status of an exact username via the resolve endpoint.
+   * Sets usernameStatus to:
+   *   - "registered"     → 200 OK (user exists in the registry)
+   *   - "not_registered" → 404 (user does not exist)
+   *   - "blacklisted"    → 200 OK + is_blacklisted flag on the response
+   *   - "checking"       → while the request is in flight
+   *   - "idle"           → when no check is needed
+   */
+  const checkUsernameRegistry = useCallback(async (username: string) => {
+    if (!username || username.length < 2) {
+      setUsernameStatus("idle");
+      return;
+    }
+    setUsernameStatus("checking");
+    try {
+      const res = await fetch(
+        `${API_BASE}/api/users/resolve/${encodeURIComponent(username)}`
+      );
+      if (res.status === 404) {
+        setUsernameStatus("not_registered");
+        return;
+      }
+      if (!res.ok) {
+        // Non-404 error — treat as unknown, keep current status
+        setUsernameStatus("idle");
+        return;
+      }
+      const body: { username: string; address: string; is_blacklisted?: boolean } =
+        await res.json();
+      if (body.is_blacklisted) {
+        setUsernameStatus("blacklisted");
+      } else {
+        setUsernameStatus("registered");
+      }
+    } catch {
+      // Network error — don't block the user from proceeding
+      setUsernameStatus("idle");
+    }
+  }, []);
+
+  // Debounce search while user types (ZAPS mode only) + registry check
   useEffect(() => {
     if (transferType !== "ZAPS") return;
     if (searchTimer.current) clearTimeout(searchTimer.current);
+
+    // Reset registry status when the user is actively typing
+    if (recipient.length >= 2) {
+      setUsernameStatus("idle");
+    }
+
     searchTimer.current = setTimeout(() => {
       searchUsers(recipient);
+      // After search settles, check the exact username against the registry
+      if (recipient.length >= 3) {
+        checkUsernameRegistry(recipient);
+      } else {
+        setUsernameStatus("idle");
+      }
     }, 350);
     return () => {
       if (searchTimer.current) clearTimeout(searchTimer.current);
     };
-  }, [recipient, transferType, searchUsers]);
+  }, [recipient, transferType, searchUsers, checkUsernameRegistry]);
 
   const handleSelectUser = useCallback((user: ZapsUser) => {
     setRecipient(user.username);
     setSelectedUser(user);
     setSearchResults([]);
     setShowDropdown(false);
+    // User selected from search results → definitely registered
+    setUsernameStatus("registered");
   }, []);
 
   useEffect(() => {
@@ -358,6 +420,8 @@ function TransferScreen() {
             onChangeText={(text: string) => {
               setRecipient(text);
               setSelectedUser(null);
+              // Reset registry warning when user edits the field
+              setUsernameStatus("idle");
               if (transferType !== "ZAPS") return;
               if (text.length < 2) {
                 setShowDropdown(false);
@@ -422,6 +486,8 @@ function TransferScreen() {
                     onPress={() => {
                       setRecipient(username);
                       setShowDropdown(false);
+                      // Check registry for recent-contact selection
+                      checkUsernameRegistry(username);
                     }}
                     activeOpacity={0.75}
                   >
@@ -443,6 +509,56 @@ function TransferScreen() {
               </View>
             )}
         </View>
+
+        {/* ── Registry status warning banners (ZAPS mode only) ──────── */}
+        {transferType === "ZAPS" && recipient.length >= 3 && (
+          <>
+            {usernameStatus === "checking" && (
+              <View style={styles.warningBanner} testID="warning-checking">
+                <ActivityIndicator size="small" color={COLORS.primary} />
+                <Text style={styles.warningBannerText}>
+                  Checking username…
+                </Text>
+              </View>
+            )}
+
+            {usernameStatus === "not_registered" && (
+              <View
+                style={[styles.warningBanner, styles.warningBannerDanger]}
+                testID="warning-not-registered"
+              >
+                <Ionicons name="alert-circle" size={20} color="#DC2626" />
+                <Text style={styles.warningBannerTextDanger}>
+                  @{recipient} is not registered on Zaps.
+                </Text>
+              </View>
+            )}
+
+            {usernameStatus === "blacklisted" && (
+              <View
+                style={[styles.warningBanner, styles.warningBannerBlacklisted]}
+                testID="warning-blacklisted"
+              >
+                <Ionicons name="shield-outline" size={20} color="#DC2626" />
+                <Text style={styles.warningBannerTextDanger}>
+                  @{recipient} has been flagged and cannot receive payments.
+                </Text>
+              </View>
+            )}
+
+            {usernameStatus === "registered" && (
+              <View
+                style={[styles.warningBanner, styles.warningBannerSuccess]}
+                testID="warning-registered"
+              >
+                <Ionicons name="checkmark-circle" size={20} color="#16A34A" />
+                <Text style={styles.warningBannerTextSuccess}>
+                  @{recipient} is a registered Zaps user.
+                </Text>
+              </View>
+            )}
+          </>
+        )}
 
         {/* Custom Amount Display */}
         <TouchableOpacity
@@ -879,7 +995,13 @@ function TransferScreen() {
             loading={step !== 3 && submitting}
             disabled={
               (step === 0 && !transferType) ||
-              (step === 1 && (!recipient || !amount)) ||
+              (step === 1 &&
+                (!recipient ||
+                  !amount ||
+                  (transferType === "ZAPS" &&
+                    recipient.length >= 3 &&
+                    (usernameStatus === "not_registered" ||
+                      usernameStatus === "blacklisted")))) ||
               (step === 3 && submitting) ||
               submitting
             }
@@ -1354,6 +1476,51 @@ const styles = StyleSheet.create({
   },
   goBackButton: {
     borderColor: "#E0E0E0",
+  },
+
+  // ── Registry status warning banners ────────────────────────────────────────
+  warningBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    marginTop: 8,
+    backgroundColor: "#F0FDF4",
+  },
+  warningBannerDanger: {
+    backgroundColor: "#FEF2F2",
+    borderWidth: 1,
+    borderColor: "#FECACA",
+  },
+  warningBannerBlacklisted: {
+    backgroundColor: "#FFF7ED",
+    borderWidth: 1,
+    borderColor: "#FED7AA",
+  },
+  warningBannerSuccess: {
+    backgroundColor: "#F0FDF4",
+    borderWidth: 1,
+    borderColor: "#BBF7D0",
+  },
+  warningBannerText: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: "Outfit_500Medium",
+    color: COLORS.primary,
+  },
+  warningBannerTextDanger: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: "Outfit_500Medium",
+    color: "#DC2626",
+  },
+  warningBannerTextSuccess: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: "Outfit_500Medium",
+    color: "#16A34A",
   },
 });
 


### PR DESCRIPTION
Closes #568

## Summary

Adds warning banners to the transfer flow that alert users when a typed ZAPS username is **not registered** or has been **blacklisted**, and disables the "Review" button when either warning is active.

## What Changed

### `mobileapp/app/transfer.tsx`
- Added `usernameStatus` state (`idle | checking | registered | not_registered | blacklisted`) to track registry validation
- Added `checkUsernameRegistry()` — calls `GET /api/users/resolve/:username` and maps:
  - **404** → `not_registered` (red warning banner)
  - **200 with `is_blacklisted: true`** → `blacklisted` (amber warning banner)
  - **200 without flag** → `registered` (green confirmation)
- Debounced resolve check fires alongside the existing user search (350ms)
- Warning banners rendered below the recipient input with clear colors + icons
- Continue button disabled when `not_registered` or `blacklisted` is active
- Handles network errors gracefully (resets to `idle`, does not block the user)

### `mobileapp/__tests__/transfer.test.tsx` (new)
- 10 tests covering: registered confirmation, unregistered warning, blacklisted warning, button disable states, checking indicator, edit-clears-warning, and external wallet mode

## Key Design Decisions

- Reuses the existing `GET /api/users/resolve/:username` endpoint — no backend changes needed
- "Blacklisted" state checks for an `is_blacklisted` field on the resolve response; the backend does not yet return this flag, so the UI infrastructure is ready for when it does
- Network errors degrade gracefully to `idle` so a flaky connection never blocks transfers
- Color scheme follows the existing UI: red (`#FEF2F2`) for errors, amber (`#FFF7ED`) for flags, green (`#F0FDF4`) for confirmations

## Acceptance Criteria Checklist

- [x] Warning banner shown when username is not registered (404 from resolve endpoint)
- [x] Warning banner shown when username is blacklisted (`is_blacklisted: true` in response)
- [x] Continue button disabled when either warning is active
- [x] Warning banners use clear, distinct colors (red/amber/green)
- [x] Registry status is checked via the resolve API, mapping response flags

## Test Results

```
Test Suites: 9 passed, 9 total
Tests:       47 passed, 47 total
```

All 47 tests pass (including 10 new transfer tests) — no regressions.

## Follow-ups

- Add an `is_blacklisted` column to the `users` table and return it from the resolve endpoint — the frontend is ready to display the banner as soon as the backend supports it.

## Security Note

No secrets, keys, or user money amounts are exposed or risked. The resolve endpoint is a public read-only lookup. All transfer authorization happens server-side via the wallet connection step (step 5).