### PR TITLE
feat(dashboard): add registry stats, usernames table, user search, payment detail modal

### DIFF
--- a/dashboard/app/dashboard/contracts/page.tsx
+++ b/dashboard/app/dashboard/contracts/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { usePolling } from "@/lib/use-polling";
 import { api } from "@/lib/api";
 import StatCard from "@/components/StatCard";
@@ -161,6 +161,83 @@ function FeeConfigPanel() {
   );
 }
 
+// ── Usernames table ───────────────────────────────────────────────────────────
+function UsernamesTable() {
+  const { data, loading, error } = usePolling(() => api.registryClaims(), 30000);
+  const [sortKey, setSortKey] = useState<"username" | "registered_at">("registered_at");
+  const [sortAsc, setSortAsc] = useState(false);
+
+  const sorted = useMemo(() => {
+    if (!data) return [];
+    return [...data].sort((a, b) => {
+      const cmp = sortKey === "username"
+        ? a.username.localeCompare(b.username)
+        : new Date(a.registered_at).getTime() - new Date(b.registered_at).getTime();
+      return sortAsc ? cmp : -cmp;
+    });
+  }, [data, sortKey, sortAsc]);
+
+  function toggleSort(key: "username" | "registered_at") {
+    if (sortKey === key) setSortAsc((v) => !v);
+    else { setSortKey(key); setSortAsc(true); }
+  }
+
+  const th = (key: "username" | "registered_at", label: string) => (
+    <th
+      className="text-left px-4 py-3 cursor-pointer select-none hover:text-slate-700"
+      onClick={() => toggleSort(key)}
+    >
+      {label} {sortKey === key ? (sortAsc ? "↑" : "↓") : ""}
+    </th>
+  );
+
+  return (
+    <section className="mb-8">
+      <h2 className="text-lg font-semibold text-slate-800 mb-3">
+        Registered Usernames
+      </h2>
+      {error && (
+        <div className="mb-3 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{error}</div>
+      )}
+      <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-slate-500 uppercase text-xs">
+            <tr>
+              {th("username", "Username")}
+              <th className="text-left px-4 py-3">Public Key</th>
+              {th("registered_at", "Registered")}
+              <th className="text-left px-4 py-3">TX Hash</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && !data ? (
+              Array.from({ length: 4 }).map((_, row) => (
+                <tr key={row}>
+                  {Array.from({ length: 4 }).map((__, col) => (
+                    <td key={col} className="px-4 py-3"><div className="h-4 animate-pulse rounded bg-slate-100" /></td>
+                  ))}
+                </tr>
+              ))
+            ) : sorted.length === 0 ? (
+              <tr><td colSpan={4} className="px-4 py-6 text-center text-slate-400">No registrations found</td></tr>
+            ) : (
+              sorted.map((c) => (
+                <tr key={c.username} className="border-t border-slate-100 hover:bg-slate-50">
+                  <td className="px-4 py-3 font-medium text-slate-900">{c.username}</td>
+                  <td className="px-4 py-3 text-slate-600 font-mono text-xs truncate max-w-[200px]">{c.public_key}</td>
+                  <td className="px-4 py-3 text-slate-500">{new Date(c.registered_at).toLocaleDateString()}</td>
+                  <td className="px-4 py-3 text-slate-500 font-mono text-xs truncate max-w-[160px]">{c.tx_hash ?? "—"}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {data && <p className="mt-2 text-xs text-slate-400">{data.length} active registrations</p>}
+    </section>
+  );
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────────
 export default function ContractsPage() {
   const health = usePolling(() => api.contractHealth(), 15000);
@@ -307,6 +384,9 @@ export default function ContractsPage() {
           </ul>
         )}
       </section>
+
+      {/* Registered usernames table */}
+      <UsernamesTable />
 
       {/* Admin section — fee coefficient */}
       <FeeConfigPanel />

--- a/dashboard/app/dashboard/layout.tsx
+++ b/dashboard/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
 import Sidebar from "@/components/Sidebar";
+import SearchBar from "@/components/SearchBar";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const { token } = useAuth();
@@ -17,7 +18,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   return (
     <div className="flex min-h-screen">
       <Sidebar />
-      <main className="ml-60 flex-1 p-6 overflow-auto">{children}</main>
+      <main className="ml-60 flex-1 p-6 overflow-auto">
+        <div className="mb-6">
+          <SearchBar />
+        </div>
+        {children}
+      </main>
     </div>
   );
 }

--- a/dashboard/app/dashboard/page.tsx
+++ b/dashboard/app/dashboard/page.tsx
@@ -24,6 +24,11 @@ export default function OverviewPage() {
     30000,
   );
 
+  const { data: registryData, loading: registryLoading, error: registryError } = usePolling(
+    () => api.registryStats(),
+    30000,
+  );
+
   const likes = feedData?.reduce((total, feed) => total + feed.likes_count, 0) ?? 0;
   const comments = feedData?.reduce((total, feed) => total + feed.comments_count, 0) ?? 0;
   const activeFeeds = feedData?.length ?? 0;
@@ -76,6 +81,52 @@ export default function OverviewPage() {
             value={activeFeeds}
             sub="Recent public feeds"
             color="text-emerald-600"
+          />
+        </div>
+      )}
+
+      {/* Username Registry */}
+      <div className="mt-10 mb-6">
+        <h2 className="text-lg font-semibold text-slate-900">Username Registry</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Registration metrics and weekly growth indicators.
+        </p>
+      </div>
+
+      {registryError && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {registryError} — showing the most recently loaded values
+        </div>
+      )}
+
+      {registryLoading && !registryData ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-28 animate-pulse rounded-xl border border-slate-200 bg-white"
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <StatCard
+            label="Total Registered"
+            value={registryData?.total_usernames ?? 0}
+            sub="Unique usernames on-chain"
+            color="text-indigo-600"
+          />
+          <StatCard
+            label="Weekly Growth"
+            value={registryData?.weekly_growth ?? 0}
+            sub="New registrations this week"
+            color="text-emerald-600"
+          />
+          <StatCard
+            label="Active Registrations"
+            value={registryData?.active_registrations ?? 0}
+            sub="Currently active claims"
+            color="text-amber-600"
           />
         </div>
       )}

--- a/dashboard/app/dashboard/transactions/page.tsx
+++ b/dashboard/app/dashboard/transactions/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { format } from "date-fns";
 import { api } from "@/lib/api";
 import { usePolling } from "@/lib/use-polling";
+import PaymentDetailDialog from "@/components/PaymentDetailDialog";
 
 const PAGE_SIZE = 20;
 
@@ -16,10 +17,15 @@ const visibilityStyles = {
 export default function TransactionsPage() {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(0);
+  const [selectedUser, setSelectedUser] = useState<string | null>(null);
   const { data, loading, error, refresh } = usePolling(
     () => api.socialFeed(),
     20000,
   );
+
+  const handleRowClick = useCallback((username: string) => {
+    setSelectedUser(username);
+  }, []);
 
   const filtered = useMemo(() => {
     const term = search.trim().toLowerCase();
@@ -130,7 +136,8 @@ export default function TransactionsPage() {
                   return (
                     <tr
                       key={feed.id}
-                      className="transition-colors hover:bg-slate-50"
+                      className="transition-colors hover:bg-slate-50 cursor-pointer"
+                      onClick={() => handleRowClick(feed.sender_username)}
                     >
                       <td className="whitespace-nowrap px-4 py-3 text-slate-600">
                         {format(new Date(feed.created_at), "MMM d, yyyy HH:mm")}
@@ -195,6 +202,12 @@ export default function TransactionsPage() {
           </div>
         )}
       </div>
+      {selectedUser && (
+        <PaymentDetailDialog
+          username={selectedUser}
+          onClose={() => setSelectedUser(null)}
+        />
+      )}
     </div>
   );
 }

--- a/dashboard/components/PaymentDetailDialog.tsx
+++ b/dashboard/components/PaymentDetailDialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { format } from "date-fns";
+import { api, type SocialFeedItem } from "@/lib/api";
+
+interface Props {
+  username: string;
+  onClose: () => void;
+}
+
+export default function PaymentDetailDialog({ username, onClose }: Props) {
+  const [payments, setPayments] = useState<SocialFeedItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    api.userPayments(username)
+      .then((data) => { if (!cancelled) setPayments(data); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load"); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [username]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="relative max-h-[80vh] w-full max-w-2xl overflow-hidden rounded-xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Payment History</h2>
+            <p className="text-sm text-slate-500">@{username}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+            aria-label="Close dialog"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="overflow-y-auto max-h-[60vh]">
+          {loading ? (
+            <div className="p-6 text-center text-sm text-slate-500">Loading…</div>
+          ) : error ? (
+            <div className="p-6 text-center text-sm text-red-600">{error}</div>
+          ) : payments.length === 0 ? (
+            <div className="p-6 text-center text-sm text-slate-400">No payments found</div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 text-xs uppercase text-slate-500 sticky top-0">
+                <tr>
+                  <th className="px-4 py-3 text-left">Date</th>
+                  <th className="px-4 py-3 text-left">Sender</th>
+                  <th className="px-4 py-3 text-left">Receiver</th>
+                  <th className="px-4 py-3 text-right">Amount</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {payments.map((p) => (
+                  <tr key={p.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 text-slate-600">
+                      {format(new Date(p.created_at), "MMM d, yyyy HH:mm")}
+                    </td>
+                    <td className="px-4 py-3 font-medium text-slate-900">{p.sender_username}</td>
+                    <td className="px-4 py-3 font-medium text-slate-900">{p.receiver_username}</td>
+                    <td className="px-4 py-3 text-right font-semibold text-slate-900">
+                      {p.amount} {p.currency}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/components/SearchBar.tsx
+++ b/dashboard/components/SearchBar.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { api, type UserSearchResult } from "@/lib/api";
+
+export default function SearchBar() {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const debouncedSearch = useCallback((value: string) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (value.trim().length < 2) {
+      setResults([]);
+      setOpen(false);
+      return;
+    }
+    timerRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const data = await api.searchUsers(value.trim());
+        setResults(data);
+        setOpen(data.length > 0);
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+  }, []);
+
+  const handleSelect = (username: string) => {
+    setQuery("");
+    setOpen(false);
+    router.push(`/dashboard/transactions?user=${encodeURIComponent(username)}`);
+  };
+
+  return (
+    <div className="relative">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          debouncedSearch(e.target.value);
+        }}
+        onFocus={() => results.length > 0 && setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 200)}
+        placeholder="Search users by username…"
+        className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm
+                   focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        aria-label="Search users by username"
+      />
+      {loading && (
+        <span className="absolute right-3 top-2.5 h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-indigo-600" />
+      )}
+      {open && (
+        <ul className="absolute z-30 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-slate-200 bg-white shadow-lg">
+          {results.map((u) => (
+            <li key={u.username}>
+              <button
+                type="button"
+                onMouseDown={() => handleSelect(u.username)}
+                className="flex w-full flex-col px-4 py-2.5 text-left text-sm hover:bg-indigo-50"
+              >
+                <span className="font-medium text-slate-900">{u.username}</span>
+                <span className="text-xs text-slate-500 truncate">{u.public_key}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -105,6 +105,19 @@ export const api = {
 
   // Yield vault aggregate metrics
   yieldStats: () => req<YieldStats>("/admin/vault/stats"),
+
+  // Username registry
+  searchUsers: (query: string) =>
+    req<UserSearchResult[]>(`/api/users/search?q=${encodeURIComponent(query)}`),
+
+  registryClaims: () =>
+    req<RegistryClaim[]>("/api/registry/claims"),
+
+  registryStats: () =>
+    req<RegistryStats>("/api/registry/stats"),
+
+  userPayments: (username: string) =>
+    req<SocialFeedItem[]>(`/api/users/${encodeURIComponent(username)}/payments`),
 };
 
 async function serverReq<T>(path: string, init?: RequestInit): Promise<T> {
@@ -261,4 +274,23 @@ export interface YieldStats {
   total_value_locked: number;
   total_yield_distributed: number;
   apy: number;
+}
+
+export interface UserSearchResult {
+  username: string;
+  public_key: string;
+  registered_at: string;
+}
+
+export interface RegistryClaim {
+  username: string;
+  public_key: string;
+  registered_at: string;
+  tx_hash?: string;
+}
+
+export interface RegistryStats {
+  total_usernames: number;
+  weekly_growth: number;
+  active_registrations: number;
 }


### PR DESCRIPTION
Closes #588
Closes #589
Closes #590
Closes #591

## What changed
- Added SearchBar component with autocomplete username lookup, redirects to user transaction details
- Added registry stats section to overview page (total usernames, weekly growth, active registrations)
- Added sortable usernames table to contracts page showing registered usernames, public keys, dates, and TX hashes
- Added PaymentDetailDialog for viewing historical payments per username on row click
- Added API functions: searchUsers, registryClaims, registryStats, userPayments