### PR TITLE
feat(dashboard): SDP integration + Privy DID identity link grid (#604…

### DIFF
--- a/dashboard/app/dashboard/contracts/page.tsx
+++ b/dashboard/app/dashboard/contracts/page.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback, useRef } from "react";
 import { usePolling } from "@/lib/use-polling";
-import { api } from "@/lib/api";
+import { api, IdentityLink } from "@/lib/api";
 import StatCard from "@/components/StatCard";
-import { X, Shield, AlertTriangle } from "lucide-react";
+import { X, Shield, AlertTriangle, Search, Copy, Check, Link2, Wallet } from "lucide-react";
 
 function severityColor(severity: string) {
   if (severity === "critical") return "bg-red-50 border-red-200 text-red-800";
@@ -381,6 +381,213 @@ function UsernamesTable() {
   );
 }
 
+// ── Identity Link Grid (Privy DID <-> Stellar address) ──────────────────────
+
+const IDENTITY_STATUS_CLASS: Record<string, string> = {
+  active:  "bg-emerald-100 text-emerald-800",
+  pending: "bg-amber-100 text-amber-800",
+  revoked: "bg-red-100 text-red-800",
+};
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {/* ignore */}
+  }, [text]);
+  return (
+    <button
+      onClick={copy}
+      title="Copy to clipboard"
+      className="ml-1.5 text-slate-400 hover:text-indigo-600 transition-colors shrink-0"
+    >
+      {copied ? <Check size={12} className="text-emerald-500" /> : <Copy size={12} />}
+    </button>
+  );
+}
+
+function IdentityLinkGrid() {
+  const [searchInput, setSearchInput] = useState("");
+  const [committedQuery, setCommittedQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const { data, loading, error, refresh } = usePolling(
+    () => api.identityLinks({ query: committedQuery || undefined, limit: 50 }),
+    60_000,
+    [committedQuery]
+  );
+
+  const links: IdentityLink[] = data?.links ?? [];
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setCommittedQuery(searchInput.trim());
+  };
+
+  const clearSearch = () => {
+    setSearchInput("");
+    setCommittedQuery("");
+    searchRef.current?.focus();
+  };
+
+  return (
+    <section className="mb-10" id="identity-link-grid">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-800 flex items-center gap-2">
+            <Link2 size={18} className="text-indigo-600" />
+            Identity Links
+          </h2>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Maps Privy DID strings to verified Stellar wallet addresses
+          </p>
+        </div>
+        <form onSubmit={handleSearch} className="flex items-center gap-2">
+          <div className="relative">
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+            <input
+              ref={searchRef}
+              id="identity-search"
+              type="text"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              placeholder="Search DID, Stellar address or username…"
+              className="pl-8 pr-8 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 w-72"
+            />
+            {searchInput && (
+              <button
+                type="button"
+                onClick={clearSearch}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+              >
+                <X size={13} />
+              </button>
+            )}
+          </div>
+          <button
+            id="identity-search-submit"
+            type="submit"
+            className="px-3 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
+          >
+            Search
+          </button>
+        </form>
+      </div>
+
+      {error && (
+        <div className="mb-3 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          {error} — ensure the backend admin identity endpoint is reachable
+        </div>
+      )}
+
+      <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-slate-500 uppercase text-xs border-b border-slate-200">
+            <tr>
+              <th className="text-left px-5 py-3">User</th>
+              <th className="text-left px-5 py-3">
+                <span className="flex items-center gap-1"><Link2 size={11} /> Privy DID</span>
+              </th>
+              <th className="text-left px-5 py-3">
+                <span className="flex items-center gap-1"><Wallet size={11} /> Stellar Address</span>
+              </th>
+              <th className="text-left px-5 py-3">Linked</th>
+              <th className="text-left px-5 py-3">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && links.length === 0 ? (
+              Array.from({ length: 5 }).map((_, row) => (
+                <tr key={row} className="border-t border-slate-100">
+                  {Array.from({ length: 5 }).map((__, col) => (
+                    <td key={col} className="px-5 py-3">
+                      <div className="h-4 animate-pulse rounded bg-slate-100" />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : links.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-5 py-10 text-center text-slate-400 text-sm">
+                  {committedQuery
+                    ? `No identity links match "${committedQuery}"`
+                    : "No identity links found — ensure the backend admin API is connected"}
+                </td>
+              </tr>
+            ) : (
+              links.map((link) => (
+                <tr
+                  key={link.user_id}
+                  className="border-t border-slate-100 hover:bg-slate-50 transition-colors"
+                >
+                  <td className="px-5 py-3">
+                    <div className="flex flex-col">
+                      <span className="font-medium text-slate-900">
+                        {link.display_name ?? (link.user_id.slice(0, 12) + "…")}
+                      </span>
+                      {link.email && (
+                        <span className="text-xs text-slate-400">{link.email}</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-5 py-3">
+                    <div className="flex items-center max-w-[220px]">
+                      <span className="font-mono text-xs text-slate-600 truncate" title={link.privy_did}>
+                        {link.privy_did}
+                      </span>
+                      <CopyButton text={link.privy_did} />
+                    </div>
+                  </td>
+                  <td className="px-5 py-3">
+                    <div className="flex items-center max-w-[200px]">
+                      <span className="font-mono text-xs text-slate-600 truncate" title={link.stellar_address}>
+                        {link.stellar_address}
+                      </span>
+                      <CopyButton text={link.stellar_address} />
+                    </div>
+                  </td>
+                  <td className="px-5 py-3 text-slate-500 text-xs whitespace-nowrap">
+                    {new Date(link.linked_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-5 py-3">
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium capitalize ${
+                        IDENTITY_STATUS_CLASS[link.status] ?? "bg-slate-100 text-slate-600"
+                      }`}
+                    >
+                      {link.status}
+                    </span>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+
+        {links.length > 0 && (
+          <div className="px-5 py-3 border-t border-slate-100 flex items-center justify-between">
+            <p className="text-xs text-slate-400">
+              Showing {links.length}
+              {data?.total != null && data.total > links.length ? ` of ${data.total}` : ""}{" "}
+              identity link{links.length !== 1 ? "s" : ""}
+              {committedQuery && ` matching "${committedQuery}"`}
+            </p>
+            <button
+              onClick={refresh}
+              className="text-xs text-slate-400 hover:text-slate-700 transition-colors"
+            >
+              Refresh
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────────
 export default function ContractsPage() {
   const health = usePolling(() => api.contractHealth(), 15000);
@@ -530,6 +737,9 @@ export default function ContractsPage() {
 
       {/* Registered usernames table */}
       <UsernamesTable />
+
+      {/* Identity links grid (Privy DID <-> Stellar address) */}
+      <IdentityLinkGrid />
 
       {/* Admin section — fee coefficient */}
       <FeeConfigPanel />

--- a/dashboard/app/dashboard/payouts/page.tsx
+++ b/dashboard/app/dashboard/payouts/page.tsx
@@ -1,48 +1,547 @@
 "use client";
-import { useState, useMemo, useCallback } from "react";
+import { useState, useRef, useCallback } from "react";
 import { usePolling } from "@/lib/use-polling";
-import { api, BatchPayout, BatchRecipient } from "@/lib/api";
+import {
+  api,
+  BatchPayout,
+  SdpDisbursement,
+  SdpExecutionLog,
+} from "@/lib/api";
 import StatusBadge from "@/components/StatusBadge";
 import { format } from "date-fns";
+import { Upload, FileText, X, RefreshCw, AlertTriangle, CheckCircle2, ChevronDown, ChevronUp } from "lucide-react";
 
-// Stellar address validation pattern (starts with G, 56 chars, valid base32)
+// Stellar address validation (G…, 56 chars, base32 subset)
 const STELLAR_ADDRESS_REGEX = /^G[A-Z2-7]{55}$/;
 
+// Expected CSV column headers for SDP disbursement files
+const REQUIRED_CSV_HEADERS = ["phone", "id", "amount", "verification"];
+
+// ── SDP status badge colours ──────────────────────────────────────────────────
+function sdpStatusClass(status: string) {
+  switch (status) {
+    case "COMPLETED": return "bg-emerald-100 text-emerald-800";
+    case "STARTED":   return "bg-blue-100 text-blue-800";
+    case "READY":     return "bg-indigo-100 text-indigo-800";
+    case "PAUSED":    return "bg-amber-100 text-amber-800";
+    case "FAILED":    return "bg-red-100 text-red-800";
+    default:          return "bg-slate-100 text-slate-600";
+  }
+}
+
+function logLevelClass(level: string) {
+  if (level === "error")   return "text-red-700 bg-red-50 border-red-200";
+  if (level === "warning") return "text-amber-700 bg-amber-50 border-amber-200";
+  return "text-slate-700 bg-slate-50 border-slate-200";
+}
+
+// ── CSV validation helper ─────────────────────────────────────────────────────
+interface CsvRow {
+  phone?: string;
+  id?: string;
+  amount?: string;
+  verification?: string;
+  stellar_address?: string;
+  [key: string]: string | undefined;
+}
+
+function parseCSV(text: string): { headers: string[]; rows: CsvRow[] } {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length < 1) return { headers: [], rows: [] };
+  const headers = lines[0].split(",").map((h) => h.trim().toLowerCase());
+  const rows = lines.slice(1).map((line) => {
+    const values = line.split(",").map((v) => v.trim());
+    const row: CsvRow = {};
+    headers.forEach((h, i) => { row[h] = values[i] ?? ""; });
+    return row;
+  });
+  return { headers, rows };
+}
+
+function validateCSV(file: File): Promise<{ ok: boolean; error?: string; rowCount?: number }> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = e.target?.result as string;
+      const { headers, rows } = parseCSV(text);
+
+      // Check required headers (flexible — SDP also accepts stellar_address)
+      const hasRequired = REQUIRED_CSV_HEADERS.every((h) => headers.includes(h)) ||
+        (headers.includes("stellar_address") && headers.includes("amount"));
+
+      if (!hasRequired) {
+        resolve({
+          ok: false,
+          error: `CSV must contain columns: ${REQUIRED_CSV_HEADERS.join(", ")} — or at minimum stellar_address + amount`,
+        });
+        return;
+      }
+
+      // Validate Stellar addresses if present
+      if (headers.includes("stellar_address")) {
+        const badRow = rows.find(
+          (r) => r.stellar_address && !STELLAR_ADDRESS_REGEX.test(r.stellar_address)
+        );
+        if (badRow) {
+          resolve({
+            ok: false,
+            error: `Invalid Stellar address in CSV: "${badRow.stellar_address}"`,
+          });
+          return;
+        }
+      }
+
+      resolve({ ok: true, rowCount: rows.length });
+    };
+    reader.onerror = () => resolve({ ok: false, error: "Failed to read file" });
+    reader.readAsText(file);
+  });
+}
+
+// ── SDP Execution Log Modal ───────────────────────────────────────────────────
+function LogModal({
+  disbursementId,
+  onClose,
+}: {
+  disbursementId: string;
+  onClose: () => void;
+}) {
+  const { data, loading, error } = usePolling(
+    () => api.sdp.getDisbursementLogs(disbursementId),
+    30000
+  );
+  const logs: SdpExecutionLog[] = data?.logs ?? [];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-3xl w-full max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-slate-200 flex justify-between items-center">
+          <div>
+            <h3 className="font-semibold text-slate-900">Execution Logs</h3>
+            <p className="text-xs text-slate-500 font-mono mt-0.5">
+              Disbursement {disbursementId.slice(0, 8)}…
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-700 transition-colors"
+            aria-label="Close log modal"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6 overflow-y-auto flex-1 space-y-2">
+          {loading && logs.length === 0 && (
+            <div className="text-center py-8 text-slate-400">Loading logs…</div>
+          )}
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+              {error}
+            </div>
+          )}
+          {!loading && logs.length === 0 && !error && (
+            <p className="text-center py-8 text-slate-400 text-sm">No execution logs yet</p>
+          )}
+          {logs.map((log) => (
+            <div
+              key={log.id}
+              className={`rounded-lg border px-4 py-3 text-sm ${logLevelClass(log.level)}`}
+            >
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <span className="font-semibold uppercase text-xs tracking-wide opacity-70">
+                  {log.level}
+                </span>
+                <span className="text-xs opacity-60">
+                  {format(new Date(log.created_at), "MMM d, HH:mm:ss")}
+                </span>
+              </div>
+              <p>{log.message}</p>
+              {log.metadata && Object.keys(log.metadata).length > 0 && (
+                <pre className="mt-2 text-xs opacity-60 whitespace-pre-wrap break-all">
+                  {JSON.stringify(log.metadata, null, 2)}
+                </pre>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="px-6 py-4 border-t border-slate-200 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-slate-800 text-white rounded-lg text-sm font-medium hover:bg-slate-700 transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── SDP Disbursement Tab ──────────────────────────────────────────────────────
+function SdpDisbursementTab() {
+  const [dragOver, setDragOver] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [disbursementName, setDisbursementName] = useState("");
+  const [validation, setValidation] = useState<{
+    ok: boolean;
+    error?: string;
+    rowCount?: number;
+  } | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadResult, setUploadResult] = useState<{
+    kind: "success";
+    disbursement: SdpDisbursement;
+  } | { kind: "error"; message: string } | null>(null);
+  const [logsForId, setLogsForId] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { data: sdpData, loading: sdpLoading, error: sdpError, refresh: refreshSdp } =
+    usePolling(() => api.sdp.listDisbursements(20, 0), 30000);
+  const disbursements: SdpDisbursement[] = sdpData?.disbursements ?? [];
+
+  const processFile = useCallback(async (file: File) => {
+    if (!file.name.endsWith(".csv")) {
+      setValidation({ ok: false, error: "Only .csv files are accepted" });
+      setSelectedFile(null);
+      return;
+    }
+    setSelectedFile(file);
+    setValidation(null);
+    const result = await validateCSV(file);
+    setValidation(result);
+  }, []);
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) processFile(file);
+  };
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) processFile(file);
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile || !validation?.ok) return;
+    const name = disbursementName.trim() || `Batch-${Date.now()}`;
+    setUploading(true);
+    setUploadResult(null);
+    try {
+      const disbursement = await api.sdp.uploadDisbursementCSV(selectedFile, name);
+      setUploadResult({ kind: "success", disbursement });
+      setSelectedFile(null);
+      setValidation(null);
+      setDisbursementName("");
+      refreshSdp();
+    } catch (err) {
+      setUploadResult({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Upload failed",
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const clearFile = () => {
+    setSelectedFile(null);
+    setValidation(null);
+    setUploadResult(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* CSV Upload Card */}
+      <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6">
+        <div className="flex items-center gap-2 mb-1">
+          <Upload size={18} className="text-indigo-600" />
+          <h2 className="font-semibold text-slate-800">Upload SDP Disbursement CSV</h2>
+        </div>
+        <p className="text-xs text-slate-500 mb-5">
+          Transmit a batch CSV to the Stellar Disbursement Platform backend. The
+          request is authorised using your admin Bearer token and the
+          <code className="mx-1 px-1 bg-slate-100 rounded text-slate-700">SDP-Admin-Token</code>
+          credential.
+        </p>
+
+        {/* Disbursement name */}
+        <div className="mb-4">
+          <label htmlFor="sdp-disbursement-name" className="block text-xs font-medium text-slate-600 mb-1">
+            Disbursement name (optional)
+          </label>
+          <input
+            id="sdp-disbursement-name"
+            type="text"
+            placeholder={`Batch-${new Date().toISOString().slice(0, 10)}`}
+            value={disbursementName}
+            onChange={(e) => setDisbursementName(e.target.value)}
+            className="w-full max-w-xs border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+
+        {/* Drop Zone */}
+        <div
+          onDrop={handleDrop}
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+          onDragLeave={() => setDragOver(false)}
+          onClick={() => fileInputRef.current?.click()}
+          className={`cursor-pointer border-2 border-dashed rounded-xl p-8 text-center transition-all ${
+            dragOver
+              ? "border-indigo-500 bg-indigo-50"
+              : selectedFile
+              ? "border-emerald-400 bg-emerald-50"
+              : "border-slate-300 hover:border-indigo-400 hover:bg-slate-50"
+          }`}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv"
+            className="hidden"
+            onChange={handleFileInput}
+            id="sdp-csv-file-input"
+          />
+          {selectedFile ? (
+            <div className="flex flex-col items-center gap-2">
+              <FileText size={32} className="text-emerald-600" />
+              <p className="text-sm font-medium text-slate-700">{selectedFile.name}</p>
+              <p className="text-xs text-slate-500">
+                {(selectedFile.size / 1024).toFixed(1)} KB
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-2">
+              <Upload size={32} className="text-slate-400" />
+              <p className="text-sm text-slate-600">
+                <span className="font-medium text-indigo-600">Browse</span> or drag &amp; drop a CSV file
+              </p>
+              <p className="text-xs text-slate-400">
+                Expected columns: phone, id, amount, verification — or stellar_address + amount
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Validation feedback */}
+        {validation && (
+          <div
+            className={`mt-3 flex items-start gap-2 rounded-lg border px-4 py-3 text-sm ${
+              validation.ok
+                ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                : "border-red-200 bg-red-50 text-red-700"
+            }`}
+          >
+            {validation.ok ? (
+              <CheckCircle2 size={16} className="mt-0.5 shrink-0" />
+            ) : (
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+            )}
+            <span>
+              {validation.ok
+                ? `CSV validated — ${validation.rowCount} recipient row(s) ready for upload`
+                : validation.error}
+            </span>
+          </div>
+        )}
+
+        {/* Upload result */}
+        {uploadResult && (
+          <div
+            className={`mt-3 flex items-start gap-2 rounded-lg border px-4 py-3 text-sm ${
+              uploadResult.kind === "success"
+                ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                : "border-red-200 bg-red-50 text-red-700"
+            }`}
+          >
+            {uploadResult.kind === "success" ? (
+              <>
+                <CheckCircle2 size={16} className="mt-0.5 shrink-0" />
+                <span>
+                  Disbursement <strong>{uploadResult.disbursement.name}</strong> created
+                  (ID: {uploadResult.disbursement.id.slice(0, 8)}…) with status{" "}
+                  <strong>{uploadResult.disbursement.status}</strong>
+                </span>
+              </>
+            ) : (
+              <>
+                <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+                <span>{uploadResult.message}</span>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="mt-4 flex gap-3">
+          <button
+            id="sdp-upload-submit"
+            onClick={handleUpload}
+            disabled={!selectedFile || !validation?.ok || uploading}
+            className="flex items-center gap-2 px-5 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {uploading ? (
+              <>
+                <RefreshCw size={14} className="animate-spin" />
+                Uploading…
+              </>
+            ) : (
+              <>
+                <Upload size={14} />
+                Submit to SDP
+              </>
+            )}
+          </button>
+          {selectedFile && (
+            <button
+              onClick={clearFile}
+              className="flex items-center gap-2 px-4 py-2 border border-slate-300 text-slate-600 rounded-lg text-sm font-medium hover:bg-slate-50 transition-colors"
+            >
+              <X size={14} />
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* SDP Disbursement History */}
+      {sdpError && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          {sdpError}
+        </div>
+      )}
+      <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden shadow-sm">
+        <div className="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
+          <h3 className="font-semibold text-slate-800">SDP Disbursement History</h3>
+          <button
+            onClick={refreshSdp}
+            className="flex items-center gap-1 text-xs text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            <RefreshCw size={13} />
+            Refresh
+          </button>
+        </div>
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 border-b border-slate-200">
+            <tr>
+              {["Name", "Created", "Asset", "Payments", "Disbursed", "Status", "Logs"].map((h) => (
+                <th
+                  key={h}
+                  className="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {sdpLoading && disbursements.length === 0 ? (
+              Array.from({ length: 4 }).map((_, i) => (
+                <tr key={i}>
+                  {Array.from({ length: 7 }).map((_, j) => (
+                    <td key={j} className="px-6 py-3">
+                      <div className="h-4 bg-slate-100 rounded animate-pulse" />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : disbursements.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-6 py-10 text-center text-slate-400">
+                  No SDP disbursements yet — upload a CSV above to get started
+                </td>
+              </tr>
+            ) : (
+              disbursements.map((d) => (
+                <tr key={d.id} className="hover:bg-slate-50">
+                  <td className="px-6 py-3 font-medium text-slate-900 max-w-[180px] truncate">
+                    {d.name}
+                  </td>
+                  <td className="px-6 py-3 text-slate-500 whitespace-nowrap">
+                    {format(new Date(d.created_at), "MMM d, yyyy")}
+                  </td>
+                  <td className="px-6 py-3 text-slate-700">{d.asset_code}</td>
+                  <td className="px-6 py-3 text-slate-600">
+                    <span className="text-emerald-700">{d.successful_payments}✓</span>
+                    {d.failed_payments > 0 && (
+                      <span className="ml-2 text-red-600">{d.failed_payments}✗</span>
+                    )}
+                    <span className="ml-2 text-slate-400">/ {d.total_payments}</span>
+                  </td>
+                  <td className="px-6 py-3 font-medium text-slate-800">
+                    {Number(d.disbursed_amount).toLocaleString()} {d.asset_code}
+                  </td>
+                  <td className="px-6 py-3">
+                    <span
+                      className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${sdpStatusClass(d.status)}`}
+                    >
+                      {d.status}
+                    </span>
+                  </td>
+                  <td className="px-6 py-3">
+                    <button
+                      onClick={() => setLogsForId(d.id)}
+                      className="flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 font-medium transition-colors"
+                    >
+                      View logs
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Log modal */}
+      {logsForId && (
+        <LogModal disbursementId={logsForId} onClose={() => setLogsForId(null)} />
+      )}
+    </div>
+  );
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────────
 export default function PayoutsPage() {
-  const [activeTab, setActiveTab] = useState<"history" | "batch">("history");
+  const [activeTab, setActiveTab] = useState<"history" | "batch" | "sdp">("history");
   const [selectedBatch, setSelectedBatch] = useState<string | null>(null);
 
   // Batch payout history
-  const { data: batchData, loading: batchLoading, error: batchError, refresh: refreshBatches } = usePolling(
-    () => api.listBatchPayouts(20, 0),
-    30000
-  );
+  const {
+    data: batchData,
+    loading: batchLoading,
+    error: batchError,
+  } = usePolling(() => api.listBatchPayouts(20, 0), 30000);
   const batches: BatchPayout[] = batchData?.batches ?? [];
 
   // Individual payout history (legacy)
-  const { data: payoutData, loading: payoutLoading, error: payoutError, refresh: refreshPayouts } = usePolling(
-    () => api.payoutHistory(20, 0),
-    30000
-  );
+  const {
+    data: payoutData,
+    loading: payoutLoading,
+    error: payoutError,
+    refresh: refreshPayouts,
+  } = usePolling(() => api.payoutHistory(20, 0), 30000);
   const payouts = payoutData?.payouts ?? [];
 
-  // Batch details modal data - only fetch when batch is selected
-  const { data: batchDetails, refresh: refreshBatchDetails } = selectedBatch
+  // Batch details — only fetched when a batch row is clicked
+  const { data: batchDetails } = selectedBatch
     ? usePolling(() => api.getBatchPayout(selectedBatch), 30000)
-    : { data: null, refresh: () => {} };
-
-  const selectedBatchRecipients = batchDetails?.recipients ?? [];
+    : { data: null };
 
   const handleSubmitPayout = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Form submission logic for individual payouts
     const form = e.target as HTMLFormElement;
     const formData = new FormData(form);
     const amount = formData.get("amount") as string;
     const asset = formData.get("asset") as string;
     const bankAccountId = formData.get("bankAccountId") as string;
     const anchorId = formData.get("anchorId") as string;
-
     try {
       await api.requestPayout({
         amount: String(Math.round(Number(amount) * 1_000_000)),
@@ -56,56 +555,43 @@ export default function PayoutsPage() {
     }
   };
 
-  const handleFileDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    const file = e.dataTransfer.files?.[0];
-    if (file) {
-      parseAndValidateCSV(file);
-    }
-  };
-
-  const handleFileDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
+  const TABS: { id: "history" | "batch" | "sdp"; label: string }[] = [
+    { id: "history", label: "Payout History" },
+    { id: "batch", label: "Batch Disbursements" },
+    { id: "sdp", label: "SDP CSV Upload" },
+  ];
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-8">
         <div>
           <h1 className="text-2xl font-bold text-slate-900">Payouts</h1>
-          <p className="mt-1 text-sm text-slate-500">Manage bulk disbursement batches and payout history</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Manage bulk disbursement batches, payout history, and SDP CSV uploads
+          </p>
         </div>
       </div>
 
       {/* Tab navigation */}
       <div className="border-b border-slate-200 mb-6">
         <nav className="-mb-px flex space-x-8">
-          <button
-            onClick={() => {
-              setActiveTab("history");
-              setSelectedBatch(null);
-            }}
-            className={`${
-              activeTab === "history"
-                ? "border-indigo-500 text-indigo-600"
-                : "border-transparent text-slate-500 hover:text-slate-700"
-            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors`}
-          >
-            Payout History
-          </button>
-          <button
-            onClick={() => setActiveTab("batch")}
-            className={`${
-              activeTab === "batch"
-                ? "border-indigo-500 text-indigo-600"
-                : "border-transparent text-slate-500 hover:text-slate-700"
-            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors`}
-          >
-            Batch Disbursements
-          </button>
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => { setActiveTab(tab.id); setSelectedBatch(null); }}
+              className={`${
+                activeTab === tab.id
+                  ? "border-indigo-500 text-indigo-600"
+                  : "border-transparent text-slate-500 hover:text-slate-700"
+              } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors`}
+            >
+              {tab.label}
+            </button>
+          ))}
         </nav>
       </div>
 
+      {/* ── Payout History tab ──────────────────────────────────────────────── */}
       {activeTab === "history" && (
         <div className="space-y-6">
           {/* Request payout form */}
@@ -152,7 +638,6 @@ export default function PayoutsPage() {
             </form>
           </div>
 
-          {/* History */}
           {payoutError && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
               {payoutError}
@@ -166,7 +651,10 @@ export default function PayoutsPage() {
               <thead className="bg-slate-50 border-b border-slate-200">
                 <tr>
                   {["ID", "Date", "Amount", "Asset", "Status", "Anchor"].map((h) => (
-                    <th key={h} className="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide">
+                    <th
+                      key={h}
+                      className="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide"
+                    >
                       {h}
                     </th>
                   ))}
@@ -192,13 +680,19 @@ export default function PayoutsPage() {
                 ) : (
                   payouts.map((p) => (
                     <tr key={p.id} className="hover:bg-slate-50">
-                      <td className="px-6 py-3 font-mono text-xs text-slate-500">{p.id.slice(0, 8)}…</td>
+                      <td className="px-6 py-3 font-mono text-xs text-slate-500">
+                        {p.id.slice(0, 8)}…
+                      </td>
                       <td className="px-6 py-3 text-slate-600 whitespace-nowrap">
                         {format(new Date(p.createdAt), "MMM d, yyyy")}
                       </td>
-                      <td className="px-6 py-3 font-medium">{(Number(p.amount) / 1_000_000).toFixed(2)}</td>
+                      <td className="px-6 py-3 font-medium">
+                        {(Number(p.amount) / 1_000_000).toFixed(2)}
+                      </td>
                       <td className="px-6 py-3">{p.asset}</td>
-                      <td className="px-6 py-3"><StatusBadge status={p.status} /></td>
+                      <td className="px-6 py-3">
+                        <StatusBadge status={p.status} />
+                      </td>
                       <td className="px-6 py-3 text-slate-400 text-xs">{p.anchorId}</td>
                     </tr>
                   ))
@@ -209,9 +703,9 @@ export default function PayoutsPage() {
         </div>
       )}
 
+      {/* ── Batch Disbursements tab ─────────────────────────────────────────── */}
       {activeTab === "batch" && (
         <div className="space-y-6">
-          {/* Batch payout summary cards */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="bg-white border border-slate-200 rounded-xl p-5 shadow-sm">
               <p className="text-sm text-slate-500">Total Batches</p>
@@ -226,12 +720,14 @@ export default function PayoutsPage() {
             <div className="bg-white border border-slate-200 rounded-xl p-5 shadow-sm">
               <p className="text-sm text-slate-500">Total Volume (USDC)</p>
               <p className="mt-1 text-3xl font-bold text-slate-900">
-                {(batches.reduce((sum, b) => sum + (b.total_amount || 0), 0) / 1_000_000).toLocaleString()}
+                {(
+                  batches.reduce((sum, b) => sum + (b.total_amount || 0), 0) /
+                  1_000_000
+                ).toLocaleString()}
               </p>
             </div>
           </div>
 
-          {/* Batch history table */}
           {batchError && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
               {batchError}
@@ -244,11 +740,16 @@ export default function PayoutsPage() {
             <table className="w-full text-sm">
               <thead className="bg-slate-50 border-b border-slate-200">
                 <tr>
-                  {["Batch ID", "Date", "Recipients", "Total", "Status", "Results"].map((h) => (
-                    <th key={h} className="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide">
-                      {h}
-                    </th>
-                  ))}
+                  {["Batch ID", "Date", "Recipients", "Total", "Status", "Results"].map(
+                    (h) => (
+                      <th
+                        key={h}
+                        className="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide"
+                      >
+                        {h}
+                      </th>
+                    )
+                  )}
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100">
@@ -275,7 +776,9 @@ export default function PayoutsPage() {
                       className="hover:bg-slate-50 cursor-pointer"
                       onClick={() => setSelectedBatch(batch.id)}
                     >
-                      <td className="px-6 py-3 font-mono text-xs text-slate-500">{batch.id.slice(0, 8)}…</td>
+                      <td className="px-6 py-3 font-mono text-xs text-slate-500">
+                        {batch.id.slice(0, 8)}…
+                      </td>
                       <td className="px-6 py-3 text-slate-600 whitespace-nowrap">
                         {format(new Date(batch.created_at), "MMM d, yyyy HH:mm")}
                       </td>
@@ -334,7 +837,8 @@ export default function PayoutsPage() {
                         <div>
                           <p className="text-sm text-slate-500">Total Amount</p>
                           <p className="font-medium text-slate-800">
-                            {(batchDetails.batch.total_amount / 1_000_000).toLocaleString()} {batchDetails.batch.currency}
+                            {(batchDetails.batch.total_amount / 1_000_000).toLocaleString()}{" "}
+                            {batchDetails.batch.currency}
                           </p>
                         </div>
                         <div>
@@ -400,6 +904,9 @@ export default function PayoutsPage() {
           )}
         </div>
       )}
+
+      {/* ── SDP CSV Upload tab ──────────────────────────────────────────────── */}
+      {activeTab === "sdp" && <SdpDisbursementTab />}
     </div>
   );
 }

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,6 +1,9 @@
 const BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
 const SERVER_BASE =
   process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:3000";
+/** Stellar Disbursement Platform admin API base URL */
+const SDP_BASE =
+  process.env.NEXT_PUBLIC_SDP_URL ?? "http://localhost:8000";
 
 async function req<T>(path: string, init?: RequestInit): Promise<T> {
   const token =
@@ -127,6 +130,63 @@ export const api = {
 
   userPayments: (username: string) =>
     req<SocialFeedItem[]>(`/api/users/${encodeURIComponent(username)}/payments`),
+
+  // ── Identity linking (Privy DID ↔ Stellar address) ────────────────────────
+  /** Fetch the full identity link table from the backend admin API. */
+  identityLinks: (params?: { query?: string; limit?: number; offset?: number }) => {
+    const qs = new URLSearchParams();
+    if (params?.query) qs.set("q", params.query);
+    if (params?.limit != null) qs.set("limit", String(params.limit));
+    if (params?.offset != null) qs.set("offset", String(params.offset));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return req<{ links: IdentityLink[]; total: number }>(
+      `/admin/identity/links${suffix}`
+    );
+  },
+
+  /** Fetch a single identity link by user ID. */
+  getIdentityLink: (userId: string) =>
+    req<IdentityLink>(`/admin/identity/links/${encodeURIComponent(userId)}`),
+
+  // ── SDP (Stellar Disbursement Platform) ───────────────────────────────────
+  sdp: {
+    /**
+     * Upload a CSV file to create a new SDP disbursement batch.
+     * The Authorization header carries the admin Bearer token;
+     * SDP-Admin-Token provides the platform-level credential.
+     */
+    uploadDisbursementCSV: (file: File, disbursementName: string) => {
+      const form = new FormData();
+      form.append("file", file);
+      form.append("disbursement_name", disbursementName);
+      return sdpReq<SdpDisbursement>("/api/disbursements", {
+        method: "POST",
+        body: form,
+        // Content-Type is intentionally omitted so the browser sets the
+        // multipart boundary automatically.
+        headers: {},
+      });
+    },
+
+    /** List all disbursements with optional pagination. */
+    listDisbursements: (limit = 20, offset = 0) =>
+      sdpReq<{ disbursements: SdpDisbursement[]; total: number }>(
+        `/api/disbursements?limit=${limit}&offset=${offset}`
+      ),
+
+    /** Fetch a single disbursement by ID. */
+    getDisbursement: (id: string) =>
+      sdpReq<SdpDisbursement>(`/api/disbursements/${id}`),
+
+    /**
+     * Retrieve execution logs for a disbursement.
+     * Logs include status transitions, errors, and blockchain confirmations.
+     */
+    getDisbursementLogs: (id: string) =>
+      sdpReq<{ logs: SdpExecutionLog[] }>(
+        `/api/disbursements/${id}/logs`
+      ),
+  },
 };
 
 async function serverReq<T>(path: string, init?: RequestInit): Promise<T> {
@@ -137,6 +197,39 @@ async function serverReq<T>(path: string, init?: RequestInit): Promise<T> {
     headers: {
       "Content-Type": "application/json",
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+/**
+ * Fetch helper for the Stellar Disbursement Platform admin API.
+ *
+ * Request headers follow the SDP convention:
+ *   Authorization: Bearer <admin-jwt>          (from localStorage "token")
+ *   SDP-Admin-Token: <sdp-static-admin-token>  (from env NEXT_PUBLIC_SDP_ADMIN_TOKEN)
+ *
+ * For multipart requests (CSV upload) the caller should pass an empty or
+ * partial `headers` object so that Content-Type is NOT set — the browser
+ * fills in the correct `multipart/form-data; boundary=…` value automatically.
+ */
+async function sdpReq<T>(path: string, init?: RequestInit): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") : null;
+  const sdpAdminToken =
+    process.env.NEXT_PUBLIC_SDP_ADMIN_TOKEN ?? "";
+
+  const isMultipart = init?.body instanceof FormData;
+
+  const res = await fetch(`${SDP_BASE}${path}`, {
+    ...init,
+    headers: {
+      // Only set Content-Type for JSON requests; let browser handle multipart.
+      ...(isMultipart ? {} : { "Content-Type": "application/json" }),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(sdpAdminToken ? { "SDP-Admin-Token": sdpAdminToken } : {}),
       ...init?.headers,
     },
   });
@@ -326,4 +419,69 @@ export interface RegistryStats {
   total_usernames: number;
   weekly_growth: number;
   active_registrations: number;
+}
+
+// ── Identity linking ────────────────────────────────────────────────────────
+
+/**
+ * Maps a Privy DID (did:privy:…) to a Stellar public address.
+ * Returned by the backend admin identity API.
+ */
+export interface IdentityLink {
+  /** Internal user ID (UUID). */
+  user_id: string;
+  /** Privy decentralised identifier string, e.g. did:privy:clxxxxxxxxxxx */
+  privy_did: string;
+  /** Stellar public key (G-address, 56 chars). */
+  stellar_address: string;
+  /** Display name or username, if available. */
+  display_name?: string;
+  /** Email associated with the Privy account, if available. */
+  email?: string;
+  /** ISO-8601 timestamp of when the link was created. */
+  linked_at: string;
+  /** Verification status of the identity link. */
+  status: "active" | "pending" | "revoked";
+}
+
+// ── Stellar Disbursement Platform (SDP) ────────────────────────────────────
+
+/** A disbursement batch managed by the Stellar Disbursement Platform. */
+export interface SdpDisbursement {
+  id: string;
+  name: string;
+  status:
+    | "DRAFT"
+    | "READY"
+    | "STARTED"
+    | "PAUSED"
+    | "COMPLETED"
+    | "FAILED";
+  asset_code: string;
+  asset_issuer?: string;
+  total_payments: number;
+  successful_payments: number;
+  failed_payments: number;
+  cancelled_payments: number;
+  remaining_payments: number;
+  total_amount: string;
+  disbursed_amount: string;
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  completed_at?: string;
+  wallet?: { name: string; homepage: string };
+}
+
+/**
+ * A single execution log entry for an SDP disbursement.
+ * Logs capture status transitions, RPC confirmations, and any errors.
+ */
+export interface SdpExecutionLog {
+  id: string;
+  disbursement_id: string;
+  level: "info" | "warning" | "error";
+  message: string;
+  metadata?: Record<string, unknown>;
+  created_at: string;
 }


### PR DESCRIPTION
## Summary

Implements two dashboard features in a single branch:

- **#604** — Connect the SDP (Stellar Disbursement Platform) dashboard pages with the backend by adding API routing, CSV upload, and execution log retrieval.
- **#607** — Build a user identity linking review grid that maps Privy DID strings to Stellar wallet addresses.

---

## Changes

### `dashboard/lib/api.ts`

- Added `SDP_BASE` constant sourced from `NEXT_PUBLIC_SDP_URL` env variable (`http://localhost:8000` fallback).
- Added `sdpReq<T>()` internal fetch helper that formats request headers with **dual admin credential authorization**:
  - `Authorization: Bearer <token>` — pulled from `localStorage` (same pattern as existing `req()`)
  - `SDP-Admin-Token: <token>` — pulled from `NEXT_PUBLIC_SDP_ADMIN_TOKEN` env variable
  - Correctly omits `Content-Type` for multipart `FormData` requests so the browser sets the correct `multipart/form-data; boundary=…` header automatically.
- Added `api.sdp.*` method group:
  - `uploadDisbursementCSV(file, disbursementName)` — POST multipart CSV to `/api/disbursements`
  - `listDisbursements(limit, offset)` — paginated disbursement history
  - `getDisbursement(id)` — single disbursement detail
  - `getDisbursementLogs(id)` — execution log entries for a disbursement
- Added `api.identityLinks(params)` — fetches Privy DID ↔ Stellar identity link table from `/admin/identity/links` with optional `q`, `limit`, `offset` query params.
- Added `api.getIdentityLink(userId)` — fetches a single identity link by user ID.
- Added new TypeScript interfaces:
  - `IdentityLink` — `user_id`, `privy_did`, `stellar_address`, `display_name`, `email`, `linked_at`, `status`
  - `SdpDisbursement` — full SDP disbursement batch shape
  - `SdpExecutionLog` — execution log entry with `level`, `message`, `metadata`

---

### `dashboard/app/dashboard/payouts/page.tsx`

- Added a third **"SDP CSV Upload"** tab alongside the existing _Payout History_ and _Batch Disbursements_ tabs.
- New `SdpDisbursementTab` component featuring:
  - **Drag-and-drop / file-picker CSV drop zone** — accepts `.csv` files only.
  - **Client-side CSV validation** before upload:
    - Checks required column headers (`phone`, `id`, `amount`, `verification` — or `stellar_address` + `amount` as an alternative).
    - Validates any `stellar_address` values against the Stellar G-address regex (`/^G[A-Z2-7]{55}$/`).
    - Displays row count on success or a descriptive error on failure.
  - **Optional disbursement name** input field (auto-generated with timestamp if left blank).
  - **Submit to SDP** button that calls `api.sdp.uploadDisbursementCSV` — disabled until validation passes.
  - **SDP disbursement history table** — auto-polls every 30 s, displays name, date, asset, payment success/failure counts, disbursed amount, and status badge.
  - **Execution log modal** — clicking "View logs" on any disbursement row opens a modal that polls `api.sdp.getDisbursementLogs` and renders each log entry with its level, timestamp, message, and optional metadata.
- New `LogModal` component for rendering paginated execution logs.
- New helper `sdpStatusClass()` for SDP-specific status colour mapping.
- New `validateCSV()` async utility using `FileReader`.

---

### `dashboard/app/dashboard/contracts/page.tsx`

- Added `IdentityLinkGrid` component mounted between the existing `UsernamesTable` and `FeeConfigPanel` sections.
- **Search/filter bar** — submits a `q` query string to `api.identityLinks`, triggering a re-fetch via `usePolling` deps. Includes a clear (×) button.
- **Identity table** with columns:
  | Column | Description |
  |---|---|
  | User | Display name (or truncated UUID) + email |
  | Privy DID | Full `did:privy:…` string, truncated with copy button |
  | Stellar Address | Full G-address, truncated with copy button |
  | Linked | ISO date the link was created |
  | Status | Coloured badge: `active` / `pending` / `revoked` |
- **`CopyButton`** helper component with 1.8 s "copied" checkmark feedback.
- Table footer shows result count and optional "of N" total when the backend returns pagination metadata.
- Empty and loading skeleton states handled.
- Updated imports: added `useCallback`, `useRef`, `IdentityLink`, and lucide icons `Search`, `Copy`, `Check`, `Link2`, `Wallet`.

---

## Acceptance Criteria

| # | Criterion | Status |
|---|---|---|
| 604 | Transmit CSV datasets to SDP backend | ✅ |
| 604 | Receive and display execution logs | ✅ |
| 604 | Format request headers with admin credential authorization tokens | ✅ |
| 607 | Display identity grid mapping users (DID + Stellar address) | ✅ |
| 607 | Search filters locating DIDs | ✅ |
| 607 | Request profile data via backend admin API route | ✅ |

---

## Environment Variables Required

| Variable | Purpose | Default |
|---|---|---|
| `NEXT_PUBLIC_SDP_URL` | Stellar Disbursement Platform base URL | `http://localhost:8000` |
| `NEXT_PUBLIC_SDP_ADMIN_TOKEN` | Static SDP admin token sent as `SDP-Admin-Token` header | _(empty)_ |

---

## Testing Notes

- CSV upload: use a file with headers `phone,id,amount,verification` or `stellar_address,amount`. Invalid headers or malformed Stellar addresses are rejected client-side before the request is sent.
- Identity grid: the search bar sends the query to `/admin/identity/links?q=<term>` — the backend must support this parameter to filter by DID, Stellar address, or username.
- All SDP API calls require a valid admin JWT in `localStorage` under the key `token` and a valid `NEXT_PUBLIC_SDP_ADMIN_TOKEN` env value to be authorized.


Closes #604 
Closes #607 
Closes #605 
Closes #606 