### PR TITLE
feat(backend): username validation, search/suggestion endpoints and registry indices (#540, #541, #545, #560)

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -153,6 +153,27 @@ components:
           type: string
           nullable: true
 
+    UserSuggestionsResponse:
+      type: object
+      properties:
+        query:
+          type: string
+          description: The normalised (lowercased, trimmed) prefix that was matched.
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchUser'
+        limit:
+          type: integer
+        offset:
+          type: integer
+        total:
+          type: integer
+          format: int64
+          description: Total matches for the prefix, ignoring limit/offset.
+        has_more:
+          type: boolean
+
     FriendUser:
       type: object
       properties:
@@ -695,9 +716,31 @@ paths:
         - name: q
           in: query
           required: true
-          description: Search term matched against username and address (ILIKE)
+          description: >-
+            Prefix matched case-insensitively against username, and
+            case-sensitively against address. LIKE metacharacters are escaped
+            and matched literally.
           schema:
             type: string
+            minLength: 1
+            maxLength: 64
+        - name: limit
+          in: query
+          required: false
+          description: Page size, clamped to 1-50.
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 50
+        - name: offset
+          in: query
+          required: false
+          description: Rows to skip; negative values are clamped to 0.
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
       responses:
         '200':
           description: Matching users
@@ -707,6 +750,74 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SearchUser'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/users/suggestions:
+    get:
+      tags:
+        - Users
+      summary: Username autocomplete suggestions (paginated)
+      description: >-
+        Username-only prefix search for autocomplete. Unlike /api/users/search
+        this validates `q` as a username prefix (lowercase alphanumeric, at most
+        15 characters) and returns a paginated envelope with the total number of
+        matches alongside each profile's avatar.
+      operationId: suggestUsernames
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: >-
+            Username prefix. Lowercased before matching; rejected with 400 if it
+            is empty, longer than 15 characters, or contains anything other than
+            lowercase letters and digits.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 15
+        - name: limit
+          in: query
+          required: false
+          description: Page size, clamped to 1-25.
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 25
+        - name: offset
+          in: query
+          required: false
+          description: Rows to skip; negative values are clamped to 0.
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: Paginated username suggestions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSuggestionsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           description: Missing or invalid JWT
           content:

--- a/backend/migrations/20260729000000_privy_did_auth_metadata.sql
+++ b/backend/migrations/20260729000000_privy_did_auth_metadata.sql
@@ -1,0 +1,33 @@
+-- #560: store the Privy DID and auth metadata on user profile records.
+--
+-- 20260726000001_privy_identity.sql introduced privy_did / privy_linked_at
+-- with a bare `ALTER TABLE ... ADD COLUMN`, which aborts if either column is
+-- already present. This migration re-states the same end state idempotently so
+-- it applies cleanly on a database where the columns were added out of band,
+-- and ships a matching rollback script under migrations/rollback/.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS privy_did VARCHAR(255);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS privy_linked_at TIMESTAMP;
+
+-- Nullable UNIQUE: a Privy DID maps to at most one account, but an account may
+-- exist without a linked DID. `ADD CONSTRAINT` has no IF NOT EXISTS form, so
+-- the catalog is checked first.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'users'::regclass
+          AND contype = 'u'
+          AND conname = 'users_privy_did_key'
+    ) THEN
+        ALTER TABLE users ADD CONSTRAINT users_privy_did_key UNIQUE (privy_did);
+    END IF;
+END
+$$;
+
+-- Lookup path for `SELECT address FROM users WHERE privy_did = $1` in
+-- api::auth::privy_auth. Partial, so the rows with no linked DID stay out of it.
+CREATE INDEX IF NOT EXISTS idx_users_privy_did
+    ON users (privy_did)
+    WHERE privy_did IS NOT NULL;

--- a/backend/migrations/20260729000001_username_indices.sql
+++ b/backend/migrations/20260729000001_username_indices.sql
@@ -1,0 +1,14 @@
+-- #541: index username mappings and enforce DB-level registration uniqueness.
+
+-- users.username already carries a plain UNIQUE constraint, but that constraint
+-- is case-sensitive: `Ebube` and `ebube` can both register and then resolve to
+-- different accounts. This makes the registry case-insensitively unique at the
+-- database level, so a racing pair of registrations cannot both commit.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username_lower
+    ON users (LOWER(username));
+
+-- Prefix lookup for the search/suggestion endpoints (`LIKE 'ebu%'`). A btree in
+-- the default collation cannot serve LIKE, so the prefix path gets its own
+-- text_pattern_ops index over the same lowercased expression.
+CREATE INDEX IF NOT EXISTS idx_users_username_lower_pattern
+    ON users (LOWER(username) text_pattern_ops);

--- a/backend/migrations/rollback/20260729000000_privy_did_auth_metadata.down.sql
+++ b/backend/migrations/rollback/20260729000000_privy_did_auth_metadata.down.sql
@@ -1,0 +1,16 @@
+-- Rollback for 20260729000000_privy_did_auth_metadata.sql (#560).
+--
+-- Dropping the columns is destructive: every linked Privy identity is lost and
+-- users have to re-link. Only the index and constraint are dropped here, which
+-- returns the schema to its pre-#560 shape without discarding data.
+--
+-- To also remove the columns (and the identity data with them), uncomment the
+-- ALTER TABLE at the bottom.
+
+DROP INDEX IF EXISTS idx_users_privy_did;
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_privy_did_key;
+
+-- ALTER TABLE users
+--     DROP COLUMN IF EXISTS privy_did,
+--     DROP COLUMN IF EXISTS privy_linked_at;

--- a/backend/migrations/rollback/20260729000001_username_indices.down.sql
+++ b/backend/migrations/rollback/20260729000001_username_indices.down.sql
@@ -1,0 +1,8 @@
+-- Rollback for 20260729000001_username_indices.sql (#541).
+--
+-- Non-destructive: these are indices only, no user data is touched. Dropping
+-- idx_users_username_lower gives up case-insensitive registration uniqueness,
+-- so `Ebube` and `ebube` become registerable as separate accounts again.
+
+DROP INDEX IF EXISTS idx_users_username_lower_pattern;
+DROP INDEX IF EXISTS idx_users_username_lower;

--- a/backend/migrations/rollback/README.md
+++ b/backend/migrations/rollback/README.md
@@ -1,0 +1,18 @@
+# Rollback scripts
+
+One `<version>_<name>.down.sql` per reversible migration in `backend/migrations/`.
+
+These are **manual**. sqlx's migrator only walks files at the top level of
+`migrations/`, so this directory is invisible to `sqlx migrate run` and to the
+`sqlx::migrate!()` bootstrap in `src/db/mod.rs` — adding a script here cannot
+change what a deploy applies.
+
+To roll a migration back, apply its script and then delete the bookkeeping row
+so the migrator will re-apply the migration on the next run:
+
+```sh
+psql "$DATABASE_URL" -f migrations/rollback/<version>_<name>.down.sql
+psql "$DATABASE_URL" -c "DELETE FROM _sqlx_migrations WHERE version = <version>;"
+```
+
+Roll back newest-first; the scripts are not written to be applied out of order.

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -71,6 +71,7 @@ pub fn user_routes_with_state(state: user::UserState) -> Router {
             get(user::get_profile).post(user::update_profile),
         )
         .route("/search", get(user::search_users))
+        .route("/suggestions", get(user::suggest_usernames))
         .route("/friends", get(user::list_friends))
         .route("/friends/request", post(user::send_friend_request))
         .route("/friends/:id/accept", post(user::accept_friend_request))

--- a/backend/src/api/user.rs
+++ b/backend/src/api/user.rs
@@ -62,9 +62,105 @@ pub struct UserSearchItem {
     pub avatar_url: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct UserSuggestionsResponse {
+    pub query: String,
+    pub results: Vec<UserSearchItem>,
+    pub limit: i64,
+    pub offset: i64,
+    pub total: i64,
+    pub has_more: bool,
+}
+
 #[derive(Deserialize)]
 pub struct FriendRequest {
     pub friend_address: String,
+}
+
+// ── #545: username syntax validation ───────────────────────────────────────
+
+/// Shortest registerable username, in characters.
+pub const USERNAME_MIN_LEN: usize = 3;
+/// Longest registerable username, in characters.
+pub const USERNAME_MAX_LEN: usize = 15;
+
+/// Why a candidate username (or username prefix) was rejected.
+#[derive(Debug, PartialEq, Eq)]
+pub enum UsernameError {
+    Empty,
+    TooShort,
+    TooLong,
+    InvalidCharacters,
+}
+
+impl UsernameError {
+    /// Client-facing reason, safe to return in an error body.
+    pub fn message(&self) -> String {
+        match self {
+            UsernameError::Empty => "username must not be empty".to_string(),
+            UsernameError::TooShort => {
+                format!("username must be at least {USERNAME_MIN_LEN} characters")
+            }
+            UsernameError::TooLong => {
+                format!("username must be at most {USERNAME_MAX_LEN} characters")
+            }
+            UsernameError::InvalidCharacters => {
+                "username may only contain lowercase letters and digits".to_string()
+            }
+        }
+    }
+}
+
+/// Validates a complete username against the registry's syntax rules:
+/// lowercase ASCII alphanumeric, 3-15 characters.
+pub fn validate_username(username: &str) -> Result<(), UsernameError> {
+    let len = username.chars().count();
+    if len < USERNAME_MIN_LEN {
+        return Err(UsernameError::TooShort);
+    }
+    if len > USERNAME_MAX_LEN {
+        return Err(UsernameError::TooLong);
+    }
+    validate_username_charset(username)
+}
+
+/// Validates a *partial* username as typed into an autocomplete box. Same
+/// charset as a full username but no minimum length, since a suggestion query
+/// is by definition shorter than the name it matches.
+pub fn validate_username_prefix(prefix: &str) -> Result<(), UsernameError> {
+    let len = prefix.chars().count();
+    if len == 0 {
+        return Err(UsernameError::Empty);
+    }
+    if len > USERNAME_MAX_LEN {
+        return Err(UsernameError::TooLong);
+    }
+    validate_username_charset(prefix)
+}
+
+fn validate_username_charset(value: &str) -> Result<(), UsernameError> {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
+        Ok(())
+    } else {
+        Err(UsernameError::InvalidCharacters)
+    }
+}
+
+/// Escapes the LIKE metacharacters so a caller-supplied term is matched
+/// literally. Pair with `ESCAPE '\'` in the query — without this, a `q` of `%`
+/// matches every row in the table.
+fn escape_like_pattern(term: &str) -> String {
+    let mut escaped = String::with_capacity(term.len());
+    for c in term.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    escaped
 }
 
 pub async fn get_profile(State(pool): State<sqlx::PgPool>, auth: AuthUser) -> impl IntoResponse {
@@ -143,24 +239,56 @@ pub async fn update_profile(
     .into_response()
 }
 
+/// Longest accepted `q` on /search. Sized for a Stellar address (56 chars),
+/// which the endpoint also matches against.
+const SEARCH_TERM_MAX_LEN: usize = 64;
+
+/// GET /api/users/search?q=&limit=&offset=
+///
+/// Prefix-matches `q` against registered usernames (case-insensitively, via the
+/// `LOWER(username)` index from #541) and against Stellar addresses. Returns a
+/// bare array for backwards compatibility with the dashboard and mobile app;
+/// `/api/users/suggestions` is the paginated form.
 pub async fn search_users(
     State(pool): State<sqlx::PgPool>,
     axum::extract::Query(params): axum::extract::Query<SearchQuery>,
 ) -> impl IntoResponse {
-    let limit = params.limit.unwrap_or(20);
-    let offset = params.offset.unwrap_or(0);
-    let query_pattern = format!("{}%", params.q);
+    let term = params.q.trim();
+    if term.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "q must not be empty" })),
+        )
+            .into_response();
+    }
+    if term.chars().count() > SEARCH_TERM_MAX_LEN {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("q must be at most {SEARCH_TERM_MAX_LEN} characters")
+            })),
+        )
+            .into_response();
+    }
+
+    let limit = params.limit.unwrap_or(20).clamp(1, 50);
+    let offset = params.offset.unwrap_or(0).max(0);
+    let escaped = escape_like_pattern(term);
+    let username_pattern = format!("{}%", escaped.to_lowercase());
+    let address_pattern = format!("{escaped}%");
 
     let rows = match sqlx::query(
         r#"
         SELECT username, address, avatar_url
         FROM users
-        WHERE username LIKE $1 OR address LIKE $1
+        WHERE LOWER(username) LIKE $1 ESCAPE '\'
+           OR address LIKE $2 ESCAPE '\'
         ORDER BY username ASC
-        LIMIT $2 OFFSET $3
+        LIMIT $3 OFFSET $4
         "#,
     )
-    .bind(&query_pattern)
+    .bind(&username_pattern)
+    .bind(&address_pattern)
     .bind(limit)
     .bind(offset)
     .fetch_all(&pool)
@@ -187,6 +315,96 @@ pub async fn search_users(
         .collect();
 
     Json(users).into_response()
+}
+
+/// GET /api/users/suggestions?q=&limit=&offset=
+///
+/// Username-only autocomplete. Unlike /search this validates `q` as a username
+/// prefix (#545) and returns a paginated envelope carrying the total match
+/// count alongside each profile's avatar.
+pub async fn suggest_usernames(
+    State(pool): State<sqlx::PgPool>,
+    axum::extract::Query(params): axum::extract::Query<SearchQuery>,
+) -> impl IntoResponse {
+    let term = params.q.trim().to_lowercase();
+    if let Err(e) = validate_username_prefix(&term) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e.message() })),
+        )
+            .into_response();
+    }
+
+    let limit = params.limit.unwrap_or(10).clamp(1, 25);
+    let offset = params.offset.unwrap_or(0).max(0);
+    // `term` is already known to be lowercase alphanumeric, so it carries no
+    // LIKE metacharacters — but escape anyway so the two endpoints cannot drift.
+    let pattern = format!("{}%", escape_like_pattern(&term));
+
+    let total: i64 = match sqlx::query_scalar(
+        r#"SELECT COUNT(*) FROM users WHERE LOWER(username) LIKE $1 ESCAPE '\'"#,
+    )
+    .bind(&pattern)
+    .fetch_one(&pool)
+    .await
+    {
+        Ok(count) => count,
+        Err(e) => {
+            tracing::error!("Username suggestion count failed: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Internal database error" })),
+            )
+                .into_response();
+        }
+    };
+
+    let rows = match sqlx::query(
+        r#"
+        SELECT username, address, avatar_url
+        FROM users
+        WHERE LOWER(username) LIKE $1 ESCAPE '\'
+        ORDER BY LOWER(username) ASC
+        LIMIT $2 OFFSET $3
+        "#,
+    )
+    .bind(&pattern)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(&pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Username suggestion query failed: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Internal database error" })),
+            )
+                .into_response();
+        }
+    };
+
+    let results: Vec<UserSearchItem> = rows
+        .into_iter()
+        .map(|row| UserSearchItem {
+            username: row.get("username"),
+            address: row.get("address"),
+            avatar_url: row.get("avatar_url"),
+        })
+        .collect();
+
+    let has_more = offset + (results.len() as i64) < total;
+
+    Json(UserSuggestionsResponse {
+        query: term,
+        results,
+        limit,
+        offset,
+        total,
+        has_more,
+    })
+    .into_response()
 }
 
 pub async fn list_friends(State(pool): State<sqlx::PgPool>, auth: AuthUser) -> impl IntoResponse {
@@ -415,6 +633,16 @@ pub async fn resolve_address(
     State(state): State<UserState>,
     Path(username): Path<String>,
 ) -> impl IntoResponse {
+    // #545: reject syntactically impossible usernames before touching Redis or
+    // Postgres — they can never resolve.
+    if let Err(e) = validate_username(&username) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e.message() })),
+        )
+            .into_response();
+    }
+
     if let Some(cache) = &state.cache {
         if let Some(address) = cache.get_address(&username).await {
             return Json(ResolveAddressResponse { username, address }).into_response();
@@ -532,7 +760,7 @@ pub async fn get_registry_stats(
     };
 
     let weekly_growth: i64 = match sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM users WHERE created_at >= NOW() - INTERVAL '7 days'"
+        "SELECT COUNT(*) FROM users WHERE created_at >= NOW() - INTERVAL '7 days'",
     )
     .fetch_one(&pool)
     .await
@@ -554,4 +782,73 @@ pub async fn get_registry_stats(
         active_registrations: total_usernames,
     })
     .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_lowercase_alphanumeric_usernames() {
+        assert_eq!(validate_username("ebube"), Ok(()));
+        assert_eq!(validate_username("zap"), Ok(()));
+        assert_eq!(validate_username("user123"), Ok(()));
+        assert_eq!(validate_username("123456789012345"), Ok(()));
+    }
+
+    #[test]
+    fn rejects_usernames_outside_length_bounds() {
+        assert_eq!(validate_username(""), Err(UsernameError::TooShort));
+        assert_eq!(validate_username("ab"), Err(UsernameError::TooShort));
+        assert_eq!(
+            validate_username("1234567890123456"),
+            Err(UsernameError::TooLong)
+        );
+    }
+
+    #[test]
+    fn rejects_uppercase_usernames() {
+        assert_eq!(
+            validate_username("Ebube"),
+            Err(UsernameError::InvalidCharacters)
+        );
+        assert_eq!(
+            validate_username("EBUBE"),
+            Err(UsernameError::InvalidCharacters)
+        );
+    }
+
+    #[test]
+    fn rejects_symbols_and_whitespace() {
+        for candidate in ["e-bube", "e_bube", "e.bube", "e bube", "ebube!", "ébube"] {
+            assert_eq!(
+                validate_username(candidate),
+                Err(UsernameError::InvalidCharacters),
+                "expected {candidate:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn prefix_validation_allows_short_terms_but_not_empty_or_invalid() {
+        assert_eq!(validate_username_prefix("e"), Ok(()));
+        assert_eq!(validate_username_prefix("eb"), Ok(()));
+        assert_eq!(validate_username_prefix(""), Err(UsernameError::Empty));
+        assert_eq!(
+            validate_username_prefix("1234567890123456"),
+            Err(UsernameError::TooLong)
+        );
+        assert_eq!(
+            validate_username_prefix("Eb"),
+            Err(UsernameError::InvalidCharacters)
+        );
+    }
+
+    #[test]
+    fn like_metacharacters_are_escaped() {
+        assert_eq!(escape_like_pattern("100%"), r"100\%");
+        assert_eq!(escape_like_pattern("a_b"), r"a\_b");
+        assert_eq!(escape_like_pattern(r"a\b"), r"a\\b");
+        assert_eq!(escape_like_pattern("ebube"), "ebube");
+    }
 }

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -8,6 +8,8 @@ CREATE TABLE IF NOT EXISTS users (
     display_name VARCHAR(100),
     bio VARCHAR(255),
     avatar_url TEXT,
+    privy_did VARCHAR(255) UNIQUE, -- Privy DID; NULL until an identity is linked
+    privy_linked_at TIMESTAMP,
     auto_earn_enabled BOOLEAN NOT NULL DEFAULT false,
     last_daily_yield_report_at TIMESTAMP,
     last_weekly_yield_report_at TIMESTAMP,
@@ -71,6 +73,11 @@ CREATE INDEX IF NOT EXISTS idx_payments_sender_id ON payments(sender_id);
 CREATE INDEX IF NOT EXISTS idx_payments_receiver_id ON payments(receiver_id);
 CREATE INDEX IF NOT EXISTS idx_users_display_name ON users(display_name);
 CREATE INDEX IF NOT EXISTS idx_users_created_at ON users(created_at DESC);
+-- Privy DID lookup (#560)
+CREATE INDEX IF NOT EXISTS idx_users_privy_did ON users(privy_did) WHERE privy_did IS NOT NULL;
+-- Username registry (#541): case-insensitive uniqueness + prefix search
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username_lower ON users(LOWER(username));
+CREATE INDEX IF NOT EXISTS idx_users_username_lower_pattern ON users(LOWER(username) text_pattern_ops);
 CREATE INDEX IF NOT EXISTS idx_bridge_tx_status ON bridge_transactions(status);
 CREATE INDEX IF NOT EXISTS idx_bridge_tx_created_at ON bridge_transactions(created_at DESC);
 


### PR DESCRIPTION
Implements the backend username/auth slice: schema + indices, a syntax validation helper, and the search/suggestion endpoints.

Closes #560
Closes #541
Closes #545
Closes #540

## What changed

### #560 — DB: Privy DID and auth metadata on the user schema
`privy_did` / `privy_linked_at` already reached `master` via `20260726000001_privy_identity.sql`, but two things were missing:

- **`src/db/schema.sql` had drifted** — the reference schema still described a `users` table with no Privy columns and no DID index. Synced.
- **No rollback path.** Added `migrations/rollback/` with a `.down.sql` per reversible migration and a README covering how to apply them. sqlx's migrator only walks files at the top level of `migrations/`, so this directory is invisible to `sqlx migrate run` and to the `sqlx::migrate!()` bootstrap — it cannot change what a deploy applies.

`20260729000000_privy_did_auth_metadata.sql` re-states that schema idempotently (`ADD COLUMN IF NOT EXISTS`, plus a `pg_constraint` check before `ADD CONSTRAINT`, which has no `IF NOT EXISTS` form), so it applies cleanly on a database where the columns were added out of band. `privy_did` stays **nullable UNIQUE**: a DID maps to at most one account, but an account may have no linked DID.

### #541 — DB: index username mappings
`users.username` already had a `UNIQUE` constraint, but it is **case-sensitive** — `Ebube` and `ebube` could both register and then resolve to different accounts.

- `idx_users_username_lower` — `UNIQUE` on `LOWER(username)`, so a racing pair of registrations cannot both commit.
- `idx_users_username_lower_pattern` — `text_pattern_ops` over the same expression. The database collation is `en_US.utf8`, where a plain btree cannot serve `LIKE`; verified the planner uses this index for prefix lookups (`Index Cond: lower(username) ~>=~ 'user12' AND ~<~ 'user13'`).

> One deploy note for reviewers: `idx_users_username_lower` will fail to build if any two existing rows differ only by case. Worth a `SELECT LOWER(username) FROM users GROUP BY 1 HAVING COUNT(*) > 1` before rolling forward on a populated environment.

### #545 — Service: username syntax validation
`validate_username` (lowercase ASCII alphanumeric, 3-15 chars) and `validate_username_prefix` (same charset, no minimum — an autocomplete term is by definition shorter than the name it matches). Hand-rolled with `chars().all(...)`; no new dependency.

Wired into `GET /api/users/resolve/:username` and the new suggestions endpoint so malformed input is rejected with `400` before it reaches Redis or Postgres. Deliberately **not** applied to `/api/users/search`, which also matches Stellar addresses and would reject them.

### #540 — API: username search and suggestions
**New `GET /api/users/suggestions?q=&limit=&offset=`** — username-only autocomplete returning a paginated envelope (`results`, `limit`, `offset`, `total`, `has_more`) with each profile's `avatar_url`.

**Hardened the existing `GET /api/users/search`:**
- LIKE metacharacters in `q` are now escaped and matched literally. Previously a `q` of `%` was interpolated straight into the pattern and matched every row in the table.
- Usernames match case-insensitively through the new `LOWER(username)` index; addresses keep their existing case-sensitive match.
- `limit` is clamped to 1-50 and `offset` floored at 0, so a caller cannot request an unbounded page.

Its response stays a **bare array** — `dashboard/lib/api.ts` and `mobileapp/app/transfer.tsx` both parse it as one, so the paginated shape went to the new endpoint rather than breaking them.

`docs/openapi.yaml` documents the new endpoint, the new query parameters, and the `400` responses.

## Verification

Run from `backend/`:

| Check | Result |
|---|---|
| `cargo build` | Same 19 errors as `upstream/master` — see baseline below |
| `cargo build` error set vs. baseline | **Byte-identical** (`diff` of sorted error lines) |
| Errors/warnings in `src/api/user.rs`, `src/api/mod.rs` | **None** |
| `rustfmt --check src/api/user.rs` | **Clean** |
| Username validator unit tests | **6/6 pass** |
| `clippy-driver -W clippy::all` on the validation helpers | **Clean** |
| All 12 migrations applied in order (postgres:15-alpine) | **All OK** |
| `src/db/schema.sql` on a fresh database | **Applies cleanly** |
| Rollback scripts | **Apply cleanly, non-destructive, migrations re-apply after** |
| `docs/openapi.yaml` | **Parses; 0 dangling `$ref`s across 34 refs** |

### Pre-existing baseline
**`upstream/master` does not compile.** `cargo build` fails with 19 errors in `src/api/yield.rs`, `src/services/sweep_worker.rs`, `src/services/stellar.rs` and others — a `stellar-base` 0.7 API mismatch (`Stroops` vs `u32`, `MIN_BASE_FEE`), a missing `deserialize_whole_number`, and an inference failure in `sweep_worker`. I captured the error set before touching anything, again after, and `diff` reports them identical, so this PR adds no new breakage. I did not attempt to fix any of it — out of scope.

Because the crate does not type-check, `cargo test` cannot run and clippy cannot reach any file. I verified the validator by extracting the helpers verbatim and compiling them standalone:

```
running 6 tests
test tests::accepts_lowercase_alphanumeric_usernames ... ok
test tests::like_metacharacters_are_escaped ... ok
test tests::prefix_validation_allows_short_terms_but_not_empty_or_invalid ... ok
test tests::rejects_symbols_and_whitespace ... ok
test tests::rejects_uppercase_usernames ... ok
test tests::rejects_usernames_outside_length_bounds ... ok

test result: ok. 6 passed; 0 failed
```

Covers a valid name, too short, too long, uppercase rejected, symbols/whitespace/non-ASCII rejected, prefix rules, and LIKE escaping. The tests live in `#[cfg(test)] mod tests` in `src/api/user.rs` and will run under `cargo test` once the crate compiles.

The migrations were checked against a real `postgres:15-alpine`, not just eyeballed. Confirmed there that `privy_did` is nullable and UNIQUE with multiple NULL rows coexisting, and that inserting `ebube` followed by `Ebube` is rejected: `duplicate key value violates unique constraint "idx_users_username_lower"`.

`cargo fmt --all` is **not** clean on `master` (11 files). I ran it, saw it rewrite files unrelated to this change, and reverted those so the diff stays reviewable. `src/api/user.rs` is fully fmt-clean; `src/api/mod.rs:47` is still flagged, but that is pre-existing formatting on `master` inside `protected_routes` — my only change to that file is the one added route line.

## Deliberately out of scope
- Fixing the pre-existing compile errors.
- Repo-wide `cargo fmt`.
- Frontend changes — `/search` stayed backwards compatible specifically to avoid needing any.
- Applying `validate_username` at registration in `api/auth.rs`. Existing rows may not satisfy the 3-15 lowercase-alphanumeric rule, so enforcing it on the write path needs a data audit first.
